### PR TITLE
Hide the quantity badge when the quantity is less than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide the quantity badge when the quantity is less then 0
 
 ## [0.5.0] - 2018-6-11
 ### Added

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -69,9 +69,9 @@ export class MiniCart extends Component {
           onMouseEnter={this.handleMouseEnterButton}
           onMouseLeave={this.handleMouseLeaveButton}>
           <CartIcon fillColor={miniCartIconColor} />
-          <span className="vtex-minicart__bagde mt1 mr1">
+          {quantity > 0 && <span className="vtex-minicart__bagde mt1 mr1">
             {quantity}
-          </span>
+          </span>}
         </Button>
         {
           (isMouseOnMiniCart || isMouseOnButton) &&

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { NoSSR } from 'render'
 import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { injectIntl, intlShape } from 'react-intl'
@@ -99,18 +100,17 @@ class MiniCartContent extends Component {
 
   render() {
     const { data, labelMiniCartEmpty, labelButton, intl, showRemoveButton } = this.props
-    let content
-    if (data.loading) {
-      content = this.renderLoading()
-    } else if (!data.orderForm || !data.orderForm.items.length) {
-      const label = labelMiniCartEmpty || intl.formatMessage({ id: 'minicart-empty' })
-      content = this.renderWithoutItems(label)
-    } else {
-      const label = labelButton || intl.formatMessage({ id: 'finish-shopping-button-label' })
-      content = this.renderMiniCartWithItems(data.orderForm, label, showRemoveButton)
-    }
-    return content
+    const labelEmpty = labelMiniCartEmpty || intl.formatMessage({ id: 'minicart-empty' })
+    const label = labelButton || intl.formatMessage({ id: 'finish-shopping-button-label' })
+    return (
+      <NoSSR onSSR={this.renderLoading()}>
+        {
+          (!data.orderForm || !data.orderForm.items.length)
+            ? this.renderWithoutItems(labelEmpty)
+            : this.renderMiniCartWithItems(data.orderForm, label, showRemoveButton)
+        }
+      </NoSSR>
+    )
   }
 }
-
 export default injectIntl(graphql(updateItemsMutation)(MiniCartContent))

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { NoSSR } from 'render'
 import PropTypes from 'prop-types'
 import { graphql } from 'react-apollo'
 import { injectIntl, intlShape } from 'react-intl'
@@ -100,17 +99,18 @@ class MiniCartContent extends Component {
 
   render() {
     const { data, labelMiniCartEmpty, labelButton, intl, showRemoveButton } = this.props
-    const labelEmpty = labelMiniCartEmpty || intl.formatMessage({ id: 'minicart-empty' })
-    const label = labelButton || intl.formatMessage({ id: 'finish-shopping-button-label' })
-    return (
-      <NoSSR onSSR={this.renderLoading()}>
-        {
-          (!data.orderForm || !data.orderForm.items.length)
-            ? this.renderWithoutItems(labelEmpty)
-            : this.renderMiniCartWithItems(data.orderForm, label, showRemoveButton)
-        }
-      </NoSSR>
-    )
+    let content
+    if (data.loading) {
+      content = this.renderLoading()
+    } else if (!data.orderForm || !data.orderForm.items.length) {
+      const label = labelMiniCartEmpty || intl.formatMessage({ id: 'minicart-empty' })
+      content = this.renderWithoutItems(label)
+    } else {
+      const label = labelButton || intl.formatMessage({ id: 'finish-shopping-button-label' })
+      content = this.renderMiniCartWithItems(data.orderForm, label, showRemoveButton)
+    }
+    return content
   }
 }
+
 export default injectIntl(graphql(updateItemsMutation)(MiniCartContent))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Hide the quantity badge when the quantity is less than 0

#### What problem is this solving?
The quantity badge was visible when quantity was zero.

#### How should this be manually tested?
https://waza2--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
