### PR TITLE
Update the pop-up to appear when the mini cart button is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- `Popup` appear when the `MiniCart` button is clicked instead of on hover.
+- `Popup` to appear when the `MiniCart` button is clicked instead of on hover.
 
 ### Fixed 
 - `maxQuantity` undefined warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `Popup` appear when the `MiniCart` button is clicked instead of on hover.
+
 ### Fixed 
 - `maxQuantity` undefined warning.
 - Loading mixed (insecure) display content warning.

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,12 +2,14 @@ import React, { Component } from 'react'
 import orderFormQuery from './graphql/orderFormQuery.gql'
 import { graphql } from 'react-apollo'
 import { Button } from 'vtex.styleguide'
+import { isMobile } from 'react-device-detect'
 
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
 import { MiniCartPropTypes } from './propTypes'
 import Sidebar from './components/Sidebar'
 import Popup from './components/Popup'
+import OutsideClickHandler from 'react-outside-click-handler'
 
 import './global.css'
 
@@ -105,10 +107,15 @@ export class MiniCart extends Component {
     document.addEventListener('item:add', this.handleItemAdd)
   }
 
-  handleClickButton = () => {
+  handleClickButton = (event) => {
     if (!this.props.hideContent) {
-      this.handleUpdateContentVisibility()
+      if (isMobile && this.props.type !== 'sidebar') {
+        location.assign('/checkout/#/cart')
+      } else {
+        this.handleUpdateContentVisibility()
+      }
     }
+    event.persist()
   }
 
   handleUpdateContentVisibility = () => {
@@ -145,7 +152,7 @@ export class MiniCart extends Component {
     } = this.props
     const { orderForm } = data
     const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
-    const large = !!((type && type === 'sidebar'))
+    const large = type && type === 'sidebar'
     const miniCartContent = (
       <MiniCartContent
         large={large}
@@ -161,27 +168,27 @@ export class MiniCart extends Component {
     )
 
     return (
-      <div className="vtex-minicart relative fr">
-        <Button variation="tertiary" icon onClick={this.handleClickButton} >
-          <CartIcon fillColor={miniCartIconColor} />
-          {quantity > 0 &&
-            <span className="vtex-minicart__bagde mt1 mr1">
-              {quantity}
-            </span>
+      <OutsideClickHandler onOutsideClick={this.handleUpdateContentVisibility}>
+        <div className="vtex-minicart relative fr">
+          <Button variation="tertiary" icon onClick={event => this.handleClickButton(event)} >
+            <CartIcon fillColor={miniCartIconColor} />
+            {quantity > 0 &&
+              <span className="vtex-minicart__bagde mt1 mr1">
+                {quantity}
+              </span>
+            }
+          </Button>
+          {!hideContent && large ? openContent &&
+            <Sidebar onBackClick={this.handleUpdateContentVisibility}>
+              {miniCartContent}
+            </Sidebar>
+            : openContent &&
+            <Popup showDiscount={showDiscount}>
+              {miniCartContent}
+            </Popup>
           }
-        </Button>
-        {!hideContent && large ? openContent &&
-          <Sidebar onBackClick={this.handleUpdateContentVisibility}>
-            {miniCartContent}
-          </Sidebar>
-          : openContent &&
-          <Popup
-            showDiscount={showDiscount}
-            onOutsideClick={this.handleUpdateContentVisibility}>
-            {miniCartContent}
-          </Popup>
-        }
-      </div>
+        </div>
+      </OutsideClickHandler>
     )
   }
 }

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -112,7 +112,9 @@ export class MiniCart extends Component {
       if (isMobile && this.props.type !== 'sidebar') {
         location.assign('/checkout/#/cart')
       } else {
-        this.handleUpdateContentVisibility()
+        this.setState({
+          openContent: !this.state.openContent,
+        })
       }
     }
     event.persist()
@@ -120,7 +122,7 @@ export class MiniCart extends Component {
 
   handleUpdateContentVisibility = () => {
     this.setState({
-      openContent: !this.state.openContent,
+      openContent: false,
     })
   }
 

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,12 +2,12 @@ import React, { Component } from 'react'
 import orderFormQuery from './graphql/orderFormQuery.gql'
 import { graphql } from 'react-apollo'
 import { Button } from 'vtex.styleguide'
-import classNames from 'classnames'
 
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
 import { MiniCartPropTypes } from './propTypes'
 import Sidebar from './components/Sidebar'
+import Popup from './components/Popup'
 
 import './global.css'
 
@@ -22,7 +22,7 @@ export class MiniCart extends Component {
   static propTypes = MiniCartPropTypes
 
   static defaultProps = {
-    maxQuantity: DEFAULT_MAX_QUANTITY
+    maxQuantity: DEFAULT_MAX_QUANTITY,
   }
 
   static getSchema = props => {
@@ -98,7 +98,7 @@ export class MiniCart extends Component {
 
   state = {
     quantityItems: 0,
-    showSideBar: false,
+    openContent: false,
   }
 
   componentDidMount() {
@@ -106,21 +106,14 @@ export class MiniCart extends Component {
   }
 
   handleClickButton = () => {
-    const { hideContent, type } = this.props
-    if (!hideContent) {
-      if (type && type === 'sidebar') {
-        this.setState({
-          showSideBar: true,
-        })
-      } else {
-        location.assign('/checkout/#/cart')
-      }
+    if (!this.props.hideContent) {
+      this.handleUpdateContentVisibility()
     }
   }
 
-  handleCloseSideBarButtonClick = () => {
+  handleUpdateContentVisibility = () => {
     this.setState({
-      showSideBar: false,
+      openContent: !this.state.openContent,
     })
   }
 
@@ -135,7 +128,9 @@ export class MiniCart extends Component {
   handleUpdateQuantityItems = quantity => this.setState({ quantityItems: quantity })
 
   render() {
-    const { showSideBar } = this.state
+    const {
+      openContent,
+    } = this.state
     const {
       labelMiniCartEmpty,
       labelButtonFinishShopping,
@@ -150,58 +145,42 @@ export class MiniCart extends Component {
     } = this.props
     const { orderForm } = data
     const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
-    const classes = classNames('mt3 bg-white relative', {
-      'vtex-minicart__content-container--footer-small': !showDiscount,
-      'vtex-minicart__content-container--footer-large': showDiscount,
-    })
+    const large = !!((type && type === 'sidebar'))
+    const miniCartContent = (
+      <MiniCartContent
+        large={large}
+        data={data}
+        onUpdateItemsQuantity={this.handleUpdateQuantityItems}
+        showRemoveButton={showRemoveButton}
+        showDiscount={showDiscount}
+        labelMiniCartEmpty={labelMiniCartEmpty}
+        labelButton={labelButtonFinishShopping}
+        enableQuantitySelector={enableQuantitySelector}
+        maxQuantity={maxQuantity}
+      />
+    )
 
     return (
       <div className="vtex-minicart relative fr">
-        <Button
-          variation="tertiary"
-          icon
-          onClick={this.handleClickButton}
-        >
+        <Button variation="tertiary" icon onClick={this.handleClickButton} >
           <CartIcon fillColor={miniCartIconColor} />
-          {quantity > 0 && <span className="vtex-minicart__bagde mt1 mr1">
-            {quantity}
-          </span>}
+          {quantity > 0 &&
+            <span className="vtex-minicart__bagde mt1 mr1">
+              {quantity}
+            </span>
+          }
         </Button>
-        {!hideContent && ((type && type === 'sidebar') ? (showSideBar &&
-          <Sidebar
-            onBackClick={this.handleCloseSideBarButtonClick}
-          >
-            <MiniCartContent
-              large
-              data={data}
-              onUpdateItemsQuantity={this.handleUpdateQuantityItems}
-              showRemoveButton={showRemoveButton}
-              showDiscount={showDiscount}
-              labelMiniCartEmpty={labelMiniCartEmpty}
-              labelButton={labelButtonFinishShopping}
-              enableQuantitySelector={enableQuantitySelector}
-              maxQuantity={maxQuantity}
-            />
-          </Sidebar>)
-          : (!showSideBar &&
-            <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
-              <div className="shadow-3">
-                <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
-                <div className={classes}>
-                  <MiniCartContent
-                    data={data}
-                    onUpdateItemsQuantity={this.handleUpdateQuantityItems}
-                    showRemoveButton={showRemoveButton}
-                    showDiscount={showDiscount}
-                    labelMiniCartEmpty={labelMiniCartEmpty}
-                    labelButton={labelButtonFinishShopping}
-                    enableQuantitySelector={enableQuantitySelector}
-                    maxQuantity={maxQuantity}
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
+        {!hideContent && large ? openContent &&
+          <Sidebar onBackClick={this.handleUpdateContentVisibility}>
+            {miniCartContent}
+          </Sidebar>
+          : openContent &&
+          <Popup
+            showDiscount={showDiscount}
+            onOutsideClick={this.handleUpdateContentVisibility}>
+            {miniCartContent}
+          </Popup>
+        }
       </div>
     )
   }

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import OutsideClickHandler from 'react-outside-click-handler'
-
 /**
  * Pop-up component.
  */
@@ -11,7 +9,6 @@ export default class Popup extends Component {
     const {
       showDiscount,
       children,
-      onOutsideClick,
     } = this.props
     const classes = classNames('mt3 bg-white relative', {
       'vtex-minicart__content-container--footer-small': !showDiscount,
@@ -19,26 +16,19 @@ export default class Popup extends Component {
     })
 
     return (
-      <OutsideClickHandler
-        onOutsideClick={onOutsideClick}
-      >
-        <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
-          <div className="shadow-3">
-            <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
-            <div className={classes}>
-              {children}
-            </div>
+      <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
+        <div className="shadow-3">
+          <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
+          <div className={classes}>
+            {children}
           </div>
         </div>
-      </OutsideClickHandler>
+      </div>
     )
   }
 }
 
 Popup.propTypes = {
-  /* Content to appear into the pop-up */
   children: PropTypes.object,
-  /* Function to be called when clicks outside this component */
-  onOutsideClick: PropTypes.func,
   showDiscount: PropTypes.bool,
 }

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import OutsideClickHandler from 'react-outside-click-handler'
+
+/**
+ * Pop-up component.
+ */
+export default class Popup extends Component {
+  render() {
+    const {
+      showDiscount,
+      children,
+      onOutsideClick,
+    } = this.props
+    const classes = classNames('mt3 bg-white relative', {
+      'vtex-minicart__content-container--footer-small': !showDiscount,
+      'vtex-minicart__content-container--footer-large': showDiscount,
+    })
+
+    return (
+      <OutsideClickHandler
+        onOutsideClick={onOutsideClick}
+      >
+        <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
+          <div className="shadow-3">
+            <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
+            <div className={classes}>
+              {children}
+            </div>
+          </div>
+        </div>
+      </OutsideClickHandler>
+    )
+  }
+}
+
+Popup.propTypes = {
+  /* Content to appear into the pop-up */
+  children: PropTypes.object,
+  /* Function to be called when clicks outside this component */
+  onOutsideClick: PropTypes.func,
+  showDiscount: PropTypes.bool,
+}

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types'
 import { IconCaretRight } from 'vtex.styleguide'
 import { injectIntl, intlShape } from 'react-intl'
 
-import OutsideClickHandler from 'react-outside-click-handler'
-
 import MiniCart from '../MiniCart'
 
 const WHITE_COLOR = '#FFFFFF'
@@ -25,23 +23,19 @@ class Sidebar extends Component {
 
     if (typeof window !== 'undefined') {
       return ReactDOM.createPortal(
-        <OutsideClickHandler
-          onOutsideClick={onBackClick}
-        >
-          <div className="vtex-minicart__sidebar fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column">
-            <div
-              className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5"
-              onClick={onBackClick}
-            >
-              <IconCaretRight size={18} color={WHITE_COLOR} />
-              <div className="mt3 ml4">
-                <MiniCart hideContent miniCartIconColor={WHITE_COLOR} />
-              </div>
-              <span className="ml4 white b ttu">{intl.formatMessage({ id: 'sidebar-title' })}</span>
+        <div className="vtex-minicart__sidebar fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column">
+          <div
+            className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5"
+            onClick={onBackClick}
+          >
+            <IconCaretRight size={18} color={WHITE_COLOR} />
+            <div className="mt3 ml4">
+              <MiniCart hideContent miniCartIconColor={WHITE_COLOR} />
             </div>
-            {this.props.children}
+            <span className="ml4 white b ttu">{intl.formatMessage({ id: 'sidebar-title' })}</span>
           </div>
-        </OutsideClickHandler>,
+          {this.props.children}
+        </div>,
         document.body
       )
     }

--- a/react/global.css
+++ b/react/global.css
@@ -1,7 +1,3 @@
-body {
-  width: 100%;
-}
-
 .vtex-minicart__item {
   height: 109px;
 }
@@ -20,12 +16,8 @@ body {
 .vtex-minicart__box {
   width: 364px;
   top: 100%;
-  display: none;
-  visibility: visible;
-}
-
-.vtex-minicart:hover .vtex-minicart__box {
   display: block;
+  visibility: visible;
 }
 
 @media only screen and (max-width: 600px) {

--- a/react/package.json
+++ b/react/package.json
@@ -11,6 +11,7 @@
     "classnames": "^2.2.5",
     "eslint-config-vtex": "^8.0.0",
     "identity-obj-proxy": "^3.0.0",
+    "react-device-detect": "^1.5.8",
     "react-outside-click-handler": "^1.2.0",
     "react-sidebar": "^2.3.2",
     "react-slick": "^0.16.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the pop-up to appear when the mini cart button is clicked instead of on hover.

#### What problem is this solving?
The pop-up was appearing when the mini cart button was on hover.

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
