### PR TITLE
Fix MiniCart of the SideBar type

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -7,5 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+ - not expected behavior when a click occurs inside the `MiniCart` of `SideBar` type.
+
 ### Added
  - Initial files and logic created.

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -169,7 +169,6 @@ export class MiniCart extends Component {
     )
 
     return (
-      
       <div className="vtex-minicart relative fr">
         <Button variation="tertiary" icon onClick={event => this.handleClickButton(event)} >
           <CartIcon fillColor={miniCartIconColor} />

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -9,7 +9,6 @@ import MiniCartContent from './components/MiniCartContent'
 import { MiniCartPropTypes } from './propTypes'
 import Sidebar from './components/Sidebar'
 import Popup from './components/Popup'
-import OutsideClickHandler from 'react-outside-click-handler'
 
 import './global.css'
 
@@ -170,27 +169,26 @@ export class MiniCart extends Component {
     )
 
     return (
-      <OutsideClickHandler onOutsideClick={this.handleUpdateContentVisibility}>
-        <div className="vtex-minicart relative fr">
-          <Button variation="tertiary" icon onClick={event => this.handleClickButton(event)} >
-            <CartIcon fillColor={miniCartIconColor} />
-            {quantity > 0 &&
-              <span className="vtex-minicart__bagde mt1 mr1">
-                {quantity}
-              </span>
-            }
-          </Button>
-          {!hideContent && large ? openContent &&
-            <Sidebar onBackClick={this.handleUpdateContentVisibility}>
-              {miniCartContent}
-            </Sidebar>
-            : openContent &&
-            <Popup showDiscount={showDiscount}>
-              {miniCartContent}
-            </Popup>
+      
+      <div className="vtex-minicart relative fr">
+        <Button variation="tertiary" icon onClick={event => this.handleClickButton(event)} >
+          <CartIcon fillColor={miniCartIconColor} />
+          {quantity > 0 &&
+            <span className="vtex-minicart__bagde mt1 mr1">
+              {quantity}
+            </span>
           }
-        </div>
-      </OutsideClickHandler>
+        </Button>
+        {!hideContent && large ? openContent &&
+          <Sidebar onOutsideClick={this.handleUpdateContentVisibility}>
+            {miniCartContent}
+          </Sidebar>
+          : openContent &&
+          <Popup showDiscount={showDiscount} onOutsideClick={this.handleUpdateContentVisibility}>
+            {miniCartContent}
+          </Popup>
+        }
+      </div>
     )
   }
 }

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import OutsideClickHandler from 'react-outside-click-handler'
 import classNames from 'classnames'
+
 /**
  * Pop-up component.
  */
@@ -9,6 +11,7 @@ export default class Popup extends Component {
     const {
       showDiscount,
       children,
+      onOutsideClick
     } = this.props
     const classes = classNames('mt3 bg-white relative', {
       'vtex-minicart__content-container--footer-small': !showDiscount,
@@ -16,14 +19,16 @@ export default class Popup extends Component {
     })
 
     return (
-      <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
-        <div className="shadow-3">
-          <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
-          <div className={classes}>
-            {children}
+      <OutsideClickHandler onOutsideClick={onOutsideClick}>
+        <div className="vtex-minicart__box absolute right-0 z-max flex flex-colunm">
+          <div className="shadow-3">
+            <div className="vtex-minicart__arrow-up absolute top-0 right-0 shadow-3" />
+            <div className={classes}>
+              {children}
+            </div>
           </div>
         </div>
-      </div>
+      </OutsideClickHandler>
     )
   }
 }
@@ -31,4 +36,6 @@ export default class Popup extends Component {
 Popup.propTypes = {
   children: PropTypes.object,
   showDiscount: PropTypes.bool,
+  /* Function to be called when click occurs outside the popup */
+  onOutsideClick: PropTypes.func,
 }

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import { IconCaretRight } from 'vtex.styleguide'
 import { injectIntl, intlShape } from 'react-intl'
+import OutsideClickHandler from 'react-outside-click-handler'
 
 import MiniCart from '../MiniCart'
 
@@ -19,23 +20,25 @@ class Sidebar extends Component {
   }
 
   render() {
-    const { onBackClick, intl } = this.props
+    const { onOutsideClick, intl } = this.props
 
     if (typeof window !== 'undefined') {
       return ReactDOM.createPortal(
-        <div className="vtex-minicart__sidebar fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column">
-          <div
-            className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5"
-            onClick={onBackClick}
-          >
-            <IconCaretRight size={18} color={WHITE_COLOR} />
-            <div className="mt3 ml4">
-              <MiniCart hideContent miniCartIconColor={WHITE_COLOR} />
+        <OutsideClickHandler onOutsideClick={onOutsideClick}>
+          <div className="vtex-minicart__sidebar fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column">
+            <div
+              className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5"
+              onClick={onOutsideClick}
+            >
+              <IconCaretRight size={18} color={WHITE_COLOR} />
+              <div className="mt3 ml4">
+                <MiniCart hideContent miniCartIconColor={WHITE_COLOR} />
+              </div>
+              <span className="ml4 white b ttu">{intl.formatMessage({ id: 'sidebar-title' })}</span>
             </div>
-            <span className="ml4 white b ttu">{intl.formatMessage({ id: 'sidebar-title' })}</span>
+            {this.props.children}
           </div>
-          {this.props.children}
-        </div>,
+        </OutsideClickHandler>,
         document.body
       )
     }
@@ -48,8 +51,8 @@ Sidebar.propTypes = {
   intl: intlShape.isRequired,
   /* Sidebar content */
   children: PropTypes.object.isRequired,
-  /* Function to be called when click in the close sidebar button */
-  onBackClick: PropTypes.func,
+  /* Function to be called when click in the close sidebar button or outside the sidebar */
+  onOutsideClick: PropTypes.func,
 }
 
 export default injectIntl(Sidebar)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix not expected behavior of SideBar Component.

#### What problem is this solving?
When a click occurs inside of the MiniCart of the SideBar type the component hided from the screen, which is a not expected behavior.

#### How should this be manually tested?

#### Screenshots or example usage
Remember to test both types of MiniCart (PopUp and SideBar)
<a href="https://gustavo--storecomponents.myvtex.com/">Workspace</a>

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
