### PR TITLE
Open minicart as sidebar in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Open sidebar independent of configuration if on mobile.
 
 ## [0.7.2] - 2018-07-25
 

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import orderFormQuery from './graphql/orderFormQuery.gql'
 import { graphql } from 'react-apollo'
 import { Button } from 'vtex.styleguide'
-import { isMobile } from 'react-device-detect'
+import isMobile from 'ismobilejs'
 
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
@@ -108,13 +108,9 @@ export class MiniCart extends Component {
 
   handleClickButton = (event) => {
     if (!this.props.hideContent) {
-      if (isMobile && this.props.type !== 'sidebar') {
-        location.assign('/checkout/#/cart')
-      } else {
-        this.setState({
-          openContent: !this.state.openContent,
-        })
-      }
+      this.setState({
+        openContent: !this.state.openContent,
+      })
     }
     event.persist()
   }
@@ -153,7 +149,7 @@ export class MiniCart extends Component {
     } = this.props
     const { orderForm } = data
     const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
-    const large = type && type === 'sidebar'
+    const large = type && type === 'sidebar' || isMobile.any
     const miniCartContent = (
       <MiniCartContent
         large={large}

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import orderFormQuery from './graphql/orderFormQuery.gql'
 import { graphql } from 'react-apollo'
 import { Button } from 'vtex.styleguide'
-import isMobile from 'ismobilejs'
 
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
@@ -97,13 +96,30 @@ export class MiniCart extends Component {
     }
   }
 
+  _mounted = false
+
   state = {
     quantityItems: 0,
     openContent: false,
+    isMobile: false,
   }
 
   componentDidMount() {
+    this._mounted = true
+
     document.addEventListener('item:add', this.handleItemAdd)
+
+    import('ismobilejs')
+      .then(module => module.default)
+      .then(isMobile => {
+        if (!this._mounted) {
+          return
+        }
+
+        this.setState({
+          isMobile: isMobile.any,
+        })
+      })
   }
 
   handleClickButton = (event) => {
@@ -122,6 +138,7 @@ export class MiniCart extends Component {
   }
 
   componentWillUnmount() {
+    this._mounted = false
     document.removeEventListener('item:add', this.handleItemAdd)
   }
 
@@ -134,6 +151,7 @@ export class MiniCart extends Component {
   render() {
     const {
       openContent,
+      isMobile,
     } = this.state
     const {
       labelMiniCartEmpty,
@@ -149,7 +167,7 @@ export class MiniCart extends Component {
     } = this.props
     const { orderForm } = data
     const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
-    const large = type && type === 'sidebar' || isMobile.any
+    const large = type && type === 'sidebar' || isMobile
     const miniCartContent = (
       <MiniCartContent
         large={large}

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import orderFormQuery from './graphql/orderFormQuery.gql'
 import { graphql } from 'react-apollo'
 import { Button } from 'vtex.styleguide'
+import { isMobile } from 'react-device-detect'
 
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
@@ -96,30 +97,13 @@ export class MiniCart extends Component {
     }
   }
 
-  _mounted = false
-
   state = {
     quantityItems: 0,
     openContent: false,
-    isMobile: false,
   }
 
   componentDidMount() {
-    this._mounted = true
-
     document.addEventListener('item:add', this.handleItemAdd)
-
-    import('ismobilejs')
-      .then(module => module.default)
-      .then(isMobile => {
-        if (!this._mounted) {
-          return
-        }
-
-        this.setState({
-          isMobile: isMobile.any,
-        })
-      })
   }
 
   handleClickButton = (event) => {
@@ -138,7 +122,6 @@ export class MiniCart extends Component {
   }
 
   componentWillUnmount() {
-    this._mounted = false
     document.removeEventListener('item:add', this.handleItemAdd)
   }
 
@@ -149,10 +132,7 @@ export class MiniCart extends Component {
   handleUpdateQuantityItems = quantity => this.setState({ quantityItems: quantity })
 
   render() {
-    const {
-      openContent,
-      isMobile,
-    } = this.state
+    const { openContent } = this.state
     const {
       labelMiniCartEmpty,
       labelButtonFinishShopping,
@@ -166,8 +146,13 @@ export class MiniCart extends Component {
       hideContent,
     } = this.props
     const { orderForm } = data
+
     const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
-    const large = type && type === 'sidebar' || isMobile
+
+    const large = type && type === 'sidebar' ||
+      isMobile ||
+      (window && window.innerWidth <= 480)
+
     const miniCartContent = (
       <MiniCartContent
         large={large}

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -11,7 +11,7 @@ export default class Popup extends Component {
     const {
       showDiscount,
       children,
-      onOutsideClick
+      onOutsideClick,
     } = this.props
     const classes = classNames('mt3 bg-white relative', {
       'vtex-minicart__content-container--footer-small': !showDiscount,

--- a/react/package.json
+++ b/react/package.json
@@ -10,7 +10,7 @@
     "@vtex/styleguide": "^3.0.2",
     "classnames": "^2.2.5",
     "identity-obj-proxy": "^3.0.0",
-    "ismobilejs": "^0.4.1",
+    "react-device-detect": "^1.5.8",
     "react-outside-click-handler": "^1.2.0",
     "react-sidebar": "^2.3.2",
     "react-slick": "^0.16.0"

--- a/react/package.json
+++ b/react/package.json
@@ -9,9 +9,8 @@
     "@vtex/product-details": "1.1.1",
     "@vtex/styleguide": "^3.0.2",
     "classnames": "^2.2.5",
-    "eslint-config-vtex": "^8.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "react-device-detect": "^1.5.8",
+    "ismobilejs": "^0.4.1",
     "react-outside-click-handler": "^1.2.0",
     "react-sidebar": "^2.3.2",
     "react-slick": "^0.16.0"
@@ -27,6 +26,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-react-intl": "^1.4.8",
     "enzyme-to-json": "^3.3.1",
+    "eslint-config-vtex": "^8.0.0",
     "graphql": "^0.13.0",
     "graphql-tag": "^2.7.3",
     "jest": "^22.2.1",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -40,9 +40,9 @@
     react-dom "^16.3.2"
     react-intl "^2.4.0"
 
-"@vtex/styleguide@2.0.0-rc.39":
-  version "2.0.0-rc.39"
-  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-2.0.0-rc.39.tgz#24b9a19b89094ccc23ad93ea545c454704ee943c"
+"@vtex/styleguide@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-3.0.2.tgz#c733da13c46d750ea8987de22d349b03eea071f0"
   dependencies:
     react-responsive-modal "^2.0.1"
     vtex-tachyons "^2.3.0"
@@ -64,6 +64,20 @@ acorn-globals@^4.1.0:
 acorn@^5.0.0, acorn@^5.3.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+airbnb-prop-types@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.10.0.tgz#c2da66a1d31c3dbe21c2fe8e758f774c718dd30d"
+  dependencies:
+    array.prototype.find "^2.0.4"
+    function.prototype.name "^1.1.0"
+    has "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    prop-types "^15.6.1"
+    prop-types-exact "^1.1.2"
 
 ajv@^5.1.0:
   version "5.5.2"
@@ -236,6 +250,13 @@ array-unique@^0.2.1:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+array.prototype.find@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -1185,6 +1206,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+"consolidated-events@^1.1.1 || ^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-2.0.2.tgz#da8d8f8c2b232831413d9e190dc11669c79f4a91"
+
 convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -1507,6 +1532,16 @@ es-abstract@^1.5.1, es-abstract@^1.6.1:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.7.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -1777,7 +1812,7 @@ function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-function.prototype.name@^1.0.3:
+function.prototype.name@^1.0.3, function.prototype.name@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
   dependencies:
@@ -1947,6 +1982,12 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 hawk@~6.0.2:
   version "6.0.2"
@@ -2294,6 +2335,10 @@ isarray@1.0.0, isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+ismobilejs@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-0.4.1.tgz#1a5f126c70fed39c93da380fa62cbae5723e7dc2"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -3490,6 +3535,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types-exact@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
+
 prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -3596,6 +3649,15 @@ react-minimalist-portal@^2.1.1:
   dependencies:
     prop-types "^15.6.0"
 
+react-outside-click-handler@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz#2c4609fbaacbfc192e269786d555419b115bf93f"
+  dependencies:
+    airbnb-prop-types "^2.10.0"
+    consolidated-events "^1.1.1 || ^2.0.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.1"
+
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
@@ -3615,6 +3677,10 @@ react-responsive-modal@^2.0.1:
     react-jss "^8.1.0"
     react-minimalist-portal "^2.1.1"
     react-transition-group "^2.2.1"
+
+react-sidebar@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/react-sidebar/-/react-sidebar-2.3.2.tgz#ec140bea8a6f5fa3d8ea7a56479665b44cf4f9cf"
 
 react-slick@^0.16.0:
   version "0.16.0"
@@ -3693,6 +3759,10 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
 
 regenerate@^1.2.1:
   version "1.3.3"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2336,10 +2336,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-ismobilejs@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-0.4.1.tgz#1a5f126c70fed39c93da380fa62cbae5723e7dc2"
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -3610,6 +3606,10 @@ react-apollo@^2.0.4:
     invariant "^2.2.2"
     lodash "4.17.5"
     prop-types "^15.6.0"
+
+react-device-detect@^1.5.8:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.5.8.tgz#a26434195145e9b23f19ade031376656e1a8e135"
 
 react-dom@^16.2.0, react-dom@^16.3.2:
   version "16.3.2"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Render the minicart sidebar when on mobile, independent of the configuration in the schema.

#### What problem is this solving?
When you were on a mobile device, and the minicart was configured to open as a popup, the user would be redirected to the checkout page.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/login).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
