### PR TITLE
Fix the mini cart item's name and sku width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `MiniCartItem`'s name width.
 
 ## [0.9.0] - 2018-08-08
 ### Fixed

--- a/react/components/MiniCartItem.js
+++ b/react/components/MiniCartItem.js
@@ -98,7 +98,7 @@ export default class MiniCartItem extends Component {
           <div className="relative bb b--silver">
             <div className="vtex-minicart__item-name mb2">
               <ProductName name={name} />
-              <div className="f7">
+              <div className="vtex-minicart__item-sku f7">
                 <ProductName name={skuName} />
               </div>
             </div>

--- a/react/components/MiniCartItem.js
+++ b/react/components/MiniCartItem.js
@@ -96,7 +96,7 @@ export default class MiniCartItem extends Component {
           page={'store/product'}
           params={{ slug: this.getItemId(detailUrl) }}>
           <div className="relative bb b--silver">
-            <div className="w-100 mb2">
+            <div className="vtex-minicart__item-name mb2">
               <ProductName name={name} />
               <div className="f7">
                 <ProductName name={skuName} />

--- a/react/global.css
+++ b/react/global.css
@@ -114,3 +114,10 @@
 .vtex-minicart__content-discount {
   color: coral;
 }
+
+.vtex-minicart__item-name > .vtex-product-name > .vtex-product-name__brand {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90%;
+}

--- a/react/global.css
+++ b/react/global.css
@@ -121,3 +121,10 @@
   text-overflow: ellipsis;
   max-width: 90%;
 }
+
+.vtex-minicart__item-sku > .vtex-product-name > .vtex-product-name__brand {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90%;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the mini cart item's name and sku width.

#### What problem is this solving?
![captura de tela de 2018-08-08 16-46-05](https://user-images.githubusercontent.com/12852518/43860634-aab229b0-9b2a-11e8-89b2-9de5fbb39a9c.png)
![captura de tela de 2018-08-08 16-45-49](https://user-images.githubusercontent.com/12852518/43860671-c9a9f0a0-9b2a-11e8-8f62-ec699e7aa471.png)

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
