### PR TITLE
Wrong place for `overflow: hidden`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `MiniCart` overflow hidden property which was affecting all the screens with at most 400px of width.
 
 ## [0.9.1] - 2018-08-09
 ### Added

--- a/react/global.css
+++ b/react/global.css
@@ -58,7 +58,7 @@
 }
 
 .vtex-minicart__bagde {
-  font-size: .71429rem;
+  font-size: 0.71429rem;
   background-color: #1790de;
   border-radius: 50%;
   color: #fff;
@@ -87,7 +87,7 @@
 }
 
 @media only screen and (max-width: 25em) {
-  body.vtex-minicart-sidebar-open {
+  body .vtex-minicart-sidebar-open {
     overflow: hidden;
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the wrong place for an `overflow: hidden` property.

#### What problem is this solving?
The property was affecting other components and hiding the vertical scrolling for  screens with at most  400px of width.

#### Screenshots or example usage

Changes that affect the minicart and the screen with at most 400px of width.
https://gugabribeiro--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
