### PR TITLE
Change mini cart to receive the icon's class-names instead of hexadecimal color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `MiniCart` to receive the icon's classnames.
+- `CartIcon` to fill the parents color.
 
 ## [1.1.1] - 2018-08-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.2] - 2018-09-05
 ### Changed
 - `MiniCart` to receive the icon's classnames.
 - `CartIcon` to fill the parents color.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -14,6 +14,8 @@ import './global.css'
 const MINIMUM_MAX_QUANTITY = 1
 const MAXIMUM_MAX_QUANTITY = 10
 const DEFAULT_MAX_QUANTITY = 1
+const DEFAULT_LABEL_CLASSES = ''
+const DEFAULT_ICON_CLASSES = 'gray'
 
 /**
  * Minicart component
@@ -23,6 +25,8 @@ export class MiniCart extends Component {
 
   static defaultProps = {
     maxQuantity: DEFAULT_MAX_QUANTITY,
+    labelClasses: DEFAULT_LABEL_CLASSES,
+    iconClasses: DEFAULT_ICON_CLASSES,
   }
 
   state = {
@@ -102,7 +106,7 @@ export class MiniCart extends Component {
           onClick={event => this.handleClickButton(event)}
         >
           <div className="flex items-center">
-            <div className={`relative ${iconClasses || 'gray'}`}>
+            <div className={`relative ${iconClasses}`}>
               <CartIcon size={iconSize} />
               {quantity > 0 && (
                 <span className="vtex-minicart__bagde white absolute f7 bg-blue h1 w1 pa1 br4 tc lh-copy">{quantity}</span>
@@ -110,7 +114,7 @@ export class MiniCart extends Component {
             </div>
             {iconLabel && (
               <span
-                className={`vtex-minicart__label f6 pl${quantity > 0 ? '6' : '4'} ${labelClasses || ''}`}
+                className={`vtex-minicart__label f6 pl${quantity > 0 ? '6' : '4'} ${labelClasses}`}
               >
                 {iconLabel}
               </span>
@@ -126,16 +130,16 @@ export class MiniCart extends Component {
               {miniCartContent}
             </Sidebar>
           ) : (
-            openContent && (
-              <Popup
-                showDiscount={showDiscount}
-                onOutsideClick={this.handleUpdateContentVisibility}
-                buttonOffsetWidth={this.iconRef.offsetWidth}
-              >
-                {miniCartContent}
-              </Popup>
-            )
-          ))}
+              openContent && (
+                <Popup
+                  showDiscount={showDiscount}
+                  onOutsideClick={this.handleUpdateContentVisibility}
+                  buttonOffsetWidth={this.iconRef.offsetWidth}
+                >
+                  {miniCartContent}
+                </Popup>
+              )
+            ))}
       </div>
     )
   }

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -53,7 +53,7 @@ export class MiniCart extends Component {
     const {
       labelMiniCartEmpty,
       labelButtonFinishShopping,
-      iconColor,
+      iconClasses,
       iconSize,
       iconLabel,
       labelClasses,
@@ -102,8 +102,8 @@ export class MiniCart extends Component {
           onClick={event => this.handleClickButton(event)}
         >
           <div className="flex items-center">
-            <div className="relative">
-              <CartIcon fillColor={iconColor} size={iconSize} />
+            <div className={`relative ${iconClasses || 'gray'}`}>
+              <CartIcon size={iconSize} />
               {quantity > 0 && (
                 <span className="vtex-minicart__bagde white absolute f7 bg-blue h1 w1 pa1 br4 tc lh-copy">{quantity}</span>
               )}

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -35,7 +35,7 @@ class Sidebar extends Component {
             <IconCaretRight size={17} color={ICON_COLOR} />
             <MiniCart
               hideContent
-              miniCartIconColor={ICON_COLOR}
+              iconClasses="mid-gray"
               labelClasses="mid-gray"
               iconLabel={intl.formatMessage({ id: 'sidebar-title' })} />
           </div>

--- a/react/images/CartIcon.js
+++ b/react/images/CartIcon.js
@@ -8,24 +8,20 @@ export default class CartIcon extends Component {
   static propTypes = {
     /* Percentage size of the icon */
     size: PropTypes.number,
-    /* Fill color for the icon */
-    fillColor: PropTypes.string,
   }
 
   static defaultProps = {
     size: 20,
-    fillColor: '#444444',
   }
 
   render() {
-    const { size, fillColor } = this.props
+    const { size } = this.props
     return (
       <svg width={size} height={size} viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0 0H8L10.6667 24H34.6667L40 8H16" transform="translate(2 2)" stroke={fillColor} strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(10 34)" stroke={fillColor} strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(31.3335 34)" stroke={fillColor} strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 0H8L10.6667 24H34.6667L40 8H16" transform="translate(2 2)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(10 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(31.3335 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-
     )
   }
 }

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -10,8 +10,8 @@ export const MiniCartPropTypes = {
   labelMiniCartEmpty: PropTypes.string,
   /* Finish shopping button label */
   labelButtonFinishShopping: PropTypes.string,
-  /* Icon's color */
-  iconColor: PropTypes.string,
+  /* Icon's classnames */
+  iconClasses: PropTypes.string,
   /* Icon's size */
   iconSize: PropTypes.number,
   /* Icon's label */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change mini cart to receive the icon's class-names instead of hexadecimal color.

#### How should this be manually tested?
[Access the workspace.](https://waza2--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
