### PR TITLE
Fixes being able to scroll the body on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.4] - 2018-09-20
 ### Fixed
 - Fixes being able to scroll the body on mobile with the `Sidebar` open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes being able to scroll the body on mobile with the `Sidebar` open.
 
 ## [1.1.3] - 2018-09-14
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/components/MiniCartItem.js
+++ b/react/components/MiniCartItem.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'render'
 import { Button, Spinner, IconClose, NumericStepper } from 'vtex.styleguide'
-import ProductName from 'vtex.store-components/ProductName'
-import ProductPrice from 'vtex.store-components/ProductPrice'
+import { ProductName, ProductPrice } from 'vtex.store-components'
+import classNames from 'classnames'
+
 import { MiniCartPropTypes } from '../propTypes'
 import Image from './Image'
 
@@ -46,11 +47,8 @@ export default class MiniCartItem extends Component {
     showRemoveButton: false,
   }
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      isRemovingItem: false,
-    }
+  state = {
+    isRemovingItem: false,
   }
 
   handleQuantityChange = event => {
@@ -87,6 +85,10 @@ export default class MiniCartItem extends Component {
 
     const { isRemovingItem } = this.state
 
+    const nameClasses = classNames('vtex-minicart__item-name h2 mb3', {
+      'vtex-minicart__item-name--large': showRemoveButton,
+    })
+
     return (
       <div className="vtex-minicart__item h4 relative w-100">
         <Link
@@ -94,11 +96,12 @@ export default class MiniCartItem extends Component {
           page={'store/product'}
           params={{ slug: this.getItemId(detailUrl) }}>
           <div className="relative bb b--silver h-100 pa4">
-            <div className={`${showRemoveButton ? 'vtex-minicart__item-name' : 'vtex-minicart__item-name-100'} h2 mb3`}>
+            <div className={nameClasses}>
               <ProductName
                 name={name}
                 skuName={skuName}
-                showSku={showSku} />
+                showSku={showSku}
+              />
             </div>
             <div className="vtex-minicart__item-footer relative flex flex-row pb2 items-center w-100">
               <div className="vtex-minicart__img-container h3 w3 mw3">
@@ -109,7 +112,8 @@ export default class MiniCartItem extends Component {
                   sellingPrice={sellingPrice * quantity}
                   listPrice={listPrice * quantity}
                   showLabels={false}
-                  showListPrice={false} />
+                  showListPrice={false}
+                />
               </div>
             </div>
           </div>
@@ -133,7 +137,8 @@ export default class MiniCartItem extends Component {
         )}
         {(showRemoveButton && isRemovingItem) && (
           <div
-            className="vtex-minicart-item__remove-btn absolute right-0 top-0 flex items-center justify-center mt3 mr4">
+            className="vtex-minicart-item__remove-btn absolute right-0 top-0 flex items-center justify-center mt3 mr4"
+          >
             <Spinner size={20} />
           </div>
         )}

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -10,26 +10,48 @@ import MiniCart from '../MiniCart'
 
 /* SideBar component */
 class Sidebar extends Component {
-  renderChildren = styles => {
+  updateComponent() {
+    if (this.props.isOpen) {
+      document.body.classList.add('vtex-minicart-sidebar-open')
+    } else {
+      document.body.classList.remove('vtex-minicart-sidebar-open')
+    }
+  }
+
+  componentDidMount() {
+    this.updateComponent()
+  }
+
+  componentDidUpdate() {
+    this.updateComponent()
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove('vtex-minicart-sidebar-open')
+  }
+
+  renderSidebar = styles => {
     const { onOutsideClick, intl } = this.props
 
     return (
       <OutsideClickHandler onOutsideClick={onOutsideClick}>
-        <div className="vtex-minicart__sidebar w-100 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
+        <div
+          className="vtex-minicart__sidebar w-100 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
           style={styles}
         >
-          <div
-            className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5 h3 shadow-4 bg-white w-100 z-max"
-            onClick={onOutsideClick}
-          >
-            <div className="mid-gray">
-              <IconCaretRight size={17} color="currentColor" />
+          <div className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5 h3 shadow-4 bg-white w-100 z-max">
+            <div
+              className="mid-gray"
+              onClick={onOutsideClick}
+            >
+              <IconCaretRight size={17} />
             </div>
             <MiniCart
               hideContent
               iconClasses="mid-gray"
               labelClasses="mid-gray"
-              iconLabel={intl.formatMessage({ id: 'sidebar-title' })} />
+              iconLabel={intl.formatMessage({ id: 'sidebar-title' })}
+            />
           </div>
           {this.props.children}
         </div>
@@ -40,20 +62,21 @@ class Sidebar extends Component {
   render() {
     const { isOpen } = this.props
 
-    if (typeof document !== 'undefined') {
-      return ReactDOM.createPortal(
-        <Transition
-          keys={isOpen ? ['children'] : []}
-          from={{ transform: 'translateX(100%)' }}
-          enter={{ transform: 'translateX(0%)' }}
-          leave={{ transform: 'translateX(100%)' }}
-        >
-          {isOpen ? [this.renderChildren] : []}
-        </Transition>,
-        document.body
-      )
+    if (typeof document === 'undefined') {
+      return null
     }
-    return null
+
+    return ReactDOM.createPortal(
+      <Transition
+        keys={isOpen ? ['children'] : []}
+        from={{ transform: 'translateX(100%)' }}
+        enter={{ transform: 'translateX(0%)' }}
+        leave={{ transform: 'translateX(100%)' }}
+      >
+        {isOpen ? [this.renderSidebar] : []}
+      </Transition>,
+      document.body
+    )
   }
 }
 

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -43,7 +43,7 @@ class Sidebar extends Component {
         >
           <div className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5 h3 shadow-4 bg-white w-100 z-max">
             <div
-              className="mid-gray"
+              className="mid-gray pa4 flex items-center"
               onClick={onOutsideClick}
             >
               <IconCaretRight size={17} />

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -8,13 +8,15 @@ import { Transition } from 'react-spring'
 
 import MiniCart from '../MiniCart'
 
+const OPEN_SIDEBAR_CLASS = 'vtex-minicart-sidebar-open'
+
 /* SideBar component */
 class Sidebar extends Component {
   updateComponent() {
     if (this.props.isOpen) {
-      document.body.classList.add('vtex-minicart-sidebar-open')
+      document.body.classList.add(OPEN_SIDEBAR_CLASS)
     } else {
-      document.body.classList.remove('vtex-minicart-sidebar-open')
+      document.body.classList.remove(OPEN_SIDEBAR_CLASS)
     }
   }
 
@@ -27,7 +29,7 @@ class Sidebar extends Component {
   }
 
   componentWillUnmount() {
-    document.body.classList.remove('vtex-minicart-sidebar-open')
+    document.body.classList.remove(OPEN_SIDEBAR_CLASS)
   }
 
   renderSidebar = styles => {

--- a/react/global.css
+++ b/react/global.css
@@ -34,10 +34,7 @@
   max-width: 90%;
 }
 
-.vtex-minicart__item-name-100 > .vtex-product-name > .vtex-product-name__brand {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.vtex-minicart__item-name--large > .vtex-product-name > .vtex-product-name__brand {
   max-width: 100%;
 }
 
@@ -56,3 +53,10 @@
 .vtex-minicart-content__footer {
   margin-top: auto;
 }
+
+@media only screen and (max-width: 20rem) {
+  body.vtex-minicart-sidebar-open {
+    overflow: hidden;
+  }
+}
+

--- a/react/global.css
+++ b/react/global.css
@@ -54,7 +54,7 @@
   margin-top: auto;
 }
 
-@media only screen and (max-width: 20rem) {
+@media only screen and (max-width: 40rem) {
   body.vtex-minicart-sidebar-open {
     overflow: hidden;
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the class `vtex-minicart-sidebar-open` when the sidebar is open to prevent scroll on the body.

#### What problem is this solving?
You shouldn't be able to scroll the body while the minicart sidebar is open.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/), access with a mobile device.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
