### PR TITLE
Fix empty message position of the MiniCartContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Empty message position of the `MiniCartContent` to be vertically centered in the pop-up mode.
 
 ## [1.1.5] - 2018-09-24
 ### Changed

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -124,7 +124,7 @@ class MiniCartContent extends Component {
   }
 
   renderWithoutItems = label => (
-    <div className="vtex-minicart__item pa4 flex items-center justify-center relative bg-white pt9">
+    <div className="vtex-minicart__item pa9 flex items-center justify-center relative bg-white">
       <span className="f5">{label}</span>
     </div>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix empty message position of the MiniCartContent to be vertically centered in the pop-up mode.

#### What problem is this solving?
![captura de tela de 2018-10-03 14-32-07](https://user-images.githubusercontent.com/12852518/46428048-53de7d80-c719-11e8-9198-ee0d47dba14c.png)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza--storecomponents.myvtex.com/)

#### Screenshots or example usage
![captura de tela de 2018-10-03 14-34-26](https://user-images.githubusercontent.com/12852518/46428109-80929500-c719-11e8-8e28-adf43e9225d4.png)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
