### PR TITLE
Change Sidebar header to use border instead of shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.1] - 2018-10-18
 ### Changed
 - `Sidebar` header to use border instead of shadow, according to the design.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `Sidebar` header to use border instead of shadow, according to the design.
 
 ## [1.1.6] - 2018-10-05
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -41,7 +41,7 @@ class Sidebar extends Component {
           className="vtex-minicart__sidebar w-100 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
           style={styles}
         >
-          <div className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5 h3 shadow-4 bg-white w-100 z-max">
+          <div className="vtex-minicart__sidebar-header pointer flex flex-row items-center pa5 h3 bg-white w-100 z-max bb b--silver bw1">
             <div
               className="mid-gray pa4 flex items-center"
               onClick={onOutsideClick}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change Sidebar header to use border instead of shadow, according to the design.

#### What problem is this solving?
![](https://trello-attachments.s3.amazonaws.com/5ad0f1fb337d4ac56d4a5686/5bb61ef056b95713d7a14165/414dfc89c7e22297aeb419e58ca6299c/Mini_cart_1.png)

#### How should this be manually tested?
[Click here to access the workspace.](https://waza3--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
