### PR TITLE
Update the minicart sidebar to 80% of the screen and change the MinicartItem to product-summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update the `MiniCartContent` component to use the `ProductSummary` from the `vtex.product-summary` instead `MiniCartItem`.
+
 
 ## [1.2.3] - 2018-11-07
 ### Changed
 - Close the `SideBar` after clicking some product's link.
+
 
 ## [1.2.2] - 2018-10-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Update the `MiniCartContent` component to use the `ProductSummary` from the `vtex.product-summary` instead `MiniCartItem`.
+- Update the size of `Sidebar` to 80% of original value.
 - Add shadow scrim.
-
 
 ## [1.2.3] - 2018-11-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Update the `MiniCartContent` component to use the `ProductSummary` from the `vtex.product-summary` instead `MiniCartItem`.
+- Add shadow scrim.
 
 
 ## [1.2.3] - 2018-11-07

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -90,6 +90,7 @@ export class MiniCart extends Component {
       isMobile ||
       (window && window.innerWidth <= 480)
 
+    
     const miniCartContent = (
       <MiniCartContent
         large={large}
@@ -102,10 +103,13 @@ export class MiniCart extends Component {
         enableQuantitySelector={enableQuantitySelector}
         maxQuantity={maxQuantity}
 <<<<<<< HEAD
+<<<<<<< HEAD
         onClickProduct={this.onClickProduct}
 =======
         handleUpdateContentVisibility={this.handleUpdateContentVisibility}
 >>>>>>> Redirect the user to product when click on item
+=======
+>>>>>>> Render product-summary fine
       />
     )
 

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -101,7 +101,11 @@ export class MiniCart extends Component {
         labelButton={labelButtonFinishShopping}
         enableQuantitySelector={enableQuantitySelector}
         maxQuantity={maxQuantity}
+<<<<<<< HEAD
         onClickProduct={this.onClickProduct}
+=======
+        handleUpdateContentVisibility={this.handleUpdateContentVisibility}
+>>>>>>> Redirect the user to product when click on item
       />
     )
 

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -2,14 +2,12 @@ import React, { Component } from 'react'
 import { Button } from 'vtex.styleguide'
 import { isMobile } from 'react-device-detect'
 import { withRuntimeContext } from 'render'
-
 import CartIcon from './images/CartIcon'
 import MiniCartContent from './components/MiniCartContent'
 import { MiniCartPropTypes } from './propTypes'
 import Sidebar from './components/Sidebar'
 import Popup from './components/Popup'
 import { orderFormConsumer } from 'vtex.store/OrderFormContext'
-
 import './global.css'
 
 const MINIMUM_MAX_QUANTITY = 1

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -101,18 +101,9 @@ export class MiniCart extends Component {
         labelButton={labelButtonFinishShopping}
         enableQuantitySelector={enableQuantitySelector}
         maxQuantity={maxQuantity}
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
         onClickProduct={this.onClickProduct}
-=======
         handleUpdateContentVisibility={this.handleUpdateContentVisibility}
->>>>>>> Redirect the user to product when click on item
-=======
->>>>>>> Render product-summary fine
-=======
         actionOnClick={this.handleUpdateContentVisibility}
->>>>>>> Closes the minicart sidebar when the item is clicked
       />
     )
 
@@ -153,15 +144,15 @@ export class MiniCart extends Component {
               {miniCartContent}
             </Sidebar>
           ) : (
-            openContent && (
-              <Popup
-                onOutsideClick={this.handleUpdateContentVisibility}
-                buttonOffsetWidth={this.iconRef.offsetWidth}
-              >
-                {miniCartContent}
-              </Popup>
-            )
-          ))}
+              openContent && (
+                <Popup
+                  onOutsideClick={this.handleUpdateContentVisibility}
+                  buttonOffsetWidth={this.iconRef.offsetWidth}
+                >
+                  {miniCartContent}
+                </Popup>
+              )
+            ))}
       </div>
     )
   }

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -90,7 +90,6 @@ export class MiniCart extends Component {
       isMobile ||
       (window && window.innerWidth <= 480)
 
-    
     const miniCartContent = (
       <MiniCartContent
         large={large}

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -104,12 +104,16 @@ export class MiniCart extends Component {
         maxQuantity={maxQuantity}
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         onClickProduct={this.onClickProduct}
 =======
         handleUpdateContentVisibility={this.handleUpdateContentVisibility}
 >>>>>>> Redirect the user to product when click on item
 =======
 >>>>>>> Render product-summary fine
+=======
+        actionOnClick={this.handleUpdateContentVisibility}
+>>>>>>> Closes the minicart sidebar when the item is clicked
       />
     )
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -3,16 +3,10 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { reduceBy, values } from 'ramda'
 import classNames from 'classnames'
-<<<<<<< HEAD
-=======
-import { ExtensionPoint } from 'render'
-<<<<<<< HEAD
 
->>>>>>> Update MinicartItem para Product Summary
-import { Button, Spinner } from 'vtex.styleguide'
-=======
+import { ExtensionPoint } from 'render'
+
 import { Button, Spinner, IconDelete } from 'vtex.styleguide'
->>>>>>> Pass deleteButton to product-summary extension point
 import ProductPrice from 'vtex.store-components/ProductPrice'
 
 import { MiniCartPropTypes } from '../propTypes'
@@ -26,6 +20,10 @@ class MiniCartContent extends Component {
     large: PropTypes.bool,
     /* Internationalization */
     intl: intlShape.isRequired,
+    /** Close the minicart sidebar when an item on click */
+    handleUpdateContentVisibility: PropTypes.func,
+
+
     /* Reused props */
     data: MiniCartPropTypes.orderFormContext,
     labelMiniCartEmpty: MiniCartPropTypes.labelMiniCartEmpty,
@@ -66,6 +64,8 @@ class MiniCartContent extends Component {
 
 
   onRemoveItem = id => {
+    this.setState({ showSpinner: true })
+
     const {
       data: { orderForm, updateAndRefetchOrderForm },
     } = this.props
@@ -142,7 +142,7 @@ class MiniCartContent extends Component {
 
     return {
       productName: item.name,
-      linkText: item.detailUrl,
+      linkText: item.detailUrl.replace(/^\//, '').replace(/\/p$/, ''),
       sku: {
         seller: {
           commertialOffer: {
@@ -162,9 +162,12 @@ class MiniCartContent extends Component {
   renderDeleteButton = (id) => {
     return (
       <Fragment>
-        <Button icon className="pa0" variation="tertiary" onClick={(e) => this.onRemoveItem(id, e)}>
-          <IconDelete size={15} color="#BDBDBD" />
-        </Button>
+        <div className="pa0-m">
+          <Button icon variation="tertiary" onClick={(e) => this.onRemoveItem(id, e)}>
+            <IconDelete size={15} color="#BDBDBD" />
+          </Button>
+        </div>
+
       </Fragment>
     )
   }
@@ -206,7 +209,6 @@ class MiniCartContent extends Component {
       <Fragment>
         <div className={classes}>
           {items.map(item => (
-
 
             <ExtensionPoint id="product-summary"
               key={item.id}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -310,6 +310,7 @@ class MiniCartContent extends Component {
       showSku,
       enableQuantitySelector,
       maxQuantity,
+      actionOnClick,
       showSpinner,
       large
     )

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -11,7 +11,6 @@ import { ExtensionPoint } from 'render'
 import { Button, Spinner } from 'vtex.styleguide'
 import ProductPrice from 'vtex.store-components/ProductPrice'
 
-import MiniCartItem from './MiniCartItem'
 import { MiniCartPropTypes } from '../propTypes'
 
 /**

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -203,21 +203,26 @@ class MiniCartContent extends Component {
       <Fragment>
         <div className={classes}>
           {items.map(item => (
-
             <Fragment>
-              <ExtensionPoint id="product-summary"
-                key={item.id}
-                product={this.createProductShapeFromItem(item)}
-                name={item.name}
-                displayMode="inline"
-                showListPrice={false}
-                showBadge={false}
-                showBorders={true}
-                showInstallments={false}
-                showLabels={false}
-                deleteButton={this.renderDeleteButton(item.id)}
-                actionOnClick={actionOnClick}
-              />
+              <div className="relative">
+                <div className="fr absolute bottom-0 right-0">
+                  <Button icon variation="tertiary" onClick={e => this.onRemoveItem(item.id, e)}>
+                    <IconDelete size={15} color="silver" />
+                  </Button>
+                </div>
+                <ExtensionPoint id="product-summary"
+                  key={item.id}
+                  product={this.createProductShapeFromItem(item)}
+                  name={item.name}
+                  displayMode="inline"
+                  showListPrice={false}
+                  showBadge={false}
+                  showBorders={true}
+                  showInstallments={false}
+                  showLabels={false}
+                  actionOnClick={actionOnClick}
+                />
+              </div>
             </Fragment>
           ))}
         </div>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { reduceBy, values } from 'ramda'
 import classNames from 'classnames'
+<<<<<<< HEAD
+=======
+import { ExtensionPoint } from 'render'
+
+>>>>>>> Update MinicartItem para Product Summary
 import { Button, Spinner } from 'vtex.styleguide'
 import ProductPrice from 'vtex.store-components/ProductPrice'
 
@@ -54,6 +59,8 @@ class MiniCartContent extends Component {
     this.sumItemsPrice(items) - totalPrice
 
   handleClickButton = () => location.assign('/checkout/#/cart')
+
+
 
   onRemoveItem = id => {
     const {
@@ -128,6 +135,27 @@ class MiniCartContent extends Component {
     </div>
   )
 
+  createProductShapeFromItem = (item) => {
+
+    return {
+      productName: item.name,
+      linkText: item.detailUrl,
+      sku: {
+        seller: {
+          commertialOffer: {
+            Price: item.sellingPrice,
+            ListPrice: item.ListPrice
+          }
+        },
+        name: item.skuName,
+        itemId: item.id,
+        image: {
+          imageUrl: item.imageUrl
+        },
+      },
+    }
+  }
+
   renderMiniCartWithItems = (
     orderForm,
     label,
@@ -152,26 +180,42 @@ class MiniCartContent extends Component {
       }
     )
 
+
+
     const discount = this.calculateDiscount(items, orderForm.value)
     const { onClickProduct } = this.props
+
 
     return (
       <Fragment>
         <div className={classes}>
           {items.map(item => (
-            <MiniCartItem
-              {...item}
+
+            <ExtensionPoint id="product-summary"
               key={item.id}
-              large
-              removeItem={this.onRemoveItem}
-              updateItem={this.onUpdateItems}
-              showRemoveButton={showRemoveButton}
-              showSku={showSku}
-              enableQuantitySelector={enableQuantitySelector}
-              maxQuantity={maxQuantity}
-              onClickProduct={onClickProduct}
+              product={this.createProductShapeFromItem(item)}
+              name={item.name}
+              displayMode="inline"
+
+
+
             />
+
+            // <MiniCartItem
+            //   {...item}
+            //   key={item.id}
+            //   large
+            //   removeItem={this.onRemoveItem}
+            //   updateItem={this.onUpdateItems}
+            //   showRemoveButton={showRemoveButton}
+            //   showSku={showSku}
+            //   enableQuantitySelector={enableQuantitySelector}
+            //   maxQuantity={maxQuantity}
+            // />
           ))}
+
+
+
         </div>
         <div
           className="vtex-minicart-content__footer w-100 bg-white pa4 bt b--silver pt4 flex flex-column items-end"

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -20,6 +20,8 @@ class MiniCartContent extends Component {
     large: PropTypes.bool,
     /* Internationalization */
     intl: intlShape.isRequired,
+    /** Define a function that is executed when the item is clicked */
+    actionOnClick: PropTypes.func,
     /* Reused props */
     data: MiniCartPropTypes.orderFormContext,
     labelMiniCartEmpty: MiniCartPropTypes.labelMiniCartEmpty,
@@ -177,8 +179,8 @@ class MiniCartContent extends Component {
     showSku,
     enableQuantitySelector,
     maxQuantity,
+    actionOnClick,
     showSpinner,
-    handleUpdateContentVisibility,
     large
   ) => {
     const items = this.getGroupedItems()
@@ -208,18 +210,21 @@ class MiniCartContent extends Component {
         <div className={classes}>
           {items.map(item => (
 
-            <ExtensionPoint id="product-summary"
-              key={item.id}
-              product={this.createProductShapeFromItem(item)}
-              name={item.name}
-              displayMode="inline"
-              showListPrice={false}
-              showBadge={false}
-              showBorders={true}
-              deleteButton={deleteButton}
-            />
-
-
+            <div >
+              <ExtensionPoint id="product-summary"
+                key={item.id}
+                product={this.createProductShapeFromItem(item)}
+                name={item.name}
+                displayMode="inline"
+                showListPrice={false}
+                showBadge={false}
+                showBorders={true}
+                showInstallments={false}
+                showLabels={false}
+                deleteButton={this.renderDeleteButton(item.id)}
+                actionOnClick={actionOnClick}
+              />
+            </div>
           ))}
 
         </div>
@@ -274,6 +279,7 @@ class MiniCartContent extends Component {
       showDiscount,
       showSku,
       enableQuantitySelector,
+      actionOnClick,
       maxQuantity,
       large,
     } = this.props

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -20,10 +20,6 @@ class MiniCartContent extends Component {
     large: PropTypes.bool,
     /* Internationalization */
     intl: intlShape.isRequired,
-    /** Close the minicart sidebar when an item on click */
-    handleUpdateContentVisibility: PropTypes.func,
-
-
     /* Reused props */
     data: MiniCartPropTypes.orderFormContext,
     labelMiniCartEmpty: MiniCartPropTypes.labelMiniCartEmpty,
@@ -182,6 +178,7 @@ class MiniCartContent extends Component {
     enableQuantitySelector,
     maxQuantity,
     showSpinner,
+    handleUpdateContentVisibility,
     large
   ) => {
     const items = this.getGroupedItems()
@@ -204,6 +201,7 @@ class MiniCartContent extends Component {
       </Button></div>
 
     </Fragment>
+
 
     return (
       <Fragment>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -181,19 +181,12 @@ class MiniCartContent extends Component {
     )
 
     const discount = this.calculateDiscount(items, orderForm.value)
-    const { onClickProduct } = this.props
-    const deleteButton = <Fragment>
-      <div className="ma0 pa0 ph0"><Button icon variation="tertiary">
-        <IconDelete className="ma0 pa0 ph8" size={20} color="#BDBDBD" />
-      </Button></div>
-
-    </Fragment>
 
     return (
       <Fragment>
         <div className={classes}>
           {items.map(item => (
-            <Fragment>
+            <Fragment key={item.id}>
               <div className="relative">
                 <div className="fr absolute bottom-0 right-0">
                   <Button icon variation="tertiary" onClick={e => this.onRemoveItem(item.id, e)}>
@@ -201,7 +194,6 @@ class MiniCartContent extends Component {
                   </Button>
                 </div>
                 <ExtensionPoint id="product-summary"
-                  key={item.id}
                   product={this.createProductShapeFromItem(item)}
                   name={item.name}
                   displayMode="inline"

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -181,7 +181,7 @@ class MiniCartContent extends Component {
         <div className={classes}>
           {items.map(item => (
             <Fragment key={item.id}>
-              <div className="relative">
+              <div className="relative flex">
                 <div className="fr absolute bottom-0 right-0">
                   <Button icon variation="tertiary" onClick={e => this.onRemoveItem(item.id)}>
                     <IconDelete size={15} color="silver" />

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { reduceBy, values } from 'ramda'
 import classNames from 'classnames'
-
 import { ExtensionPoint } from 'render'
-
 import { Button, Spinner, IconDelete } from 'vtex.styleguide'
 import ProductPrice from 'vtex.store-components/ProductPrice'
-
 import { MiniCartPropTypes } from '../propTypes'
 
 /**
@@ -191,12 +188,12 @@ class MiniCartContent extends Component {
                   </Button>
                 </div>
                 <ExtensionPoint id="product-summary"
+                  showBorders
                   product={this.createProductShapeFromItem(item)}
                   name={item.name}
                   displayMode="inline"
                   showListPrice={false}
                   showBadge={false}
-                  showBorders={true}
                   showInstallments={false}
                   showLabels={false}
                   actionOnClick={actionOnClick}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -202,10 +202,7 @@ class MiniCartContent extends Component {
             </Fragment>
           ))}
         </div>
-        <div
-          className="vtex-minicart-content__footer w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end"
-        >
-
+        <div className="vtex-minicart-content__footer w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end">
           {showDiscount && (
             <div className="vtex-minicart__content-discount blue w-100 flex justify-end items-center">
               <span className="ttl c-action-primary">{labelDiscount}</span>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -180,8 +180,6 @@ class MiniCartContent extends Component {
       }
     )
 
-
-
     const discount = this.calculateDiscount(items, orderForm.value)
     const { onClickProduct } = this.props
 
@@ -190,28 +188,15 @@ class MiniCartContent extends Component {
       <Fragment>
         <div className={classes}>
           {items.map(item => (
-
             <ExtensionPoint id="product-summary"
               key={item.id}
               product={this.createProductShapeFromItem(item)}
               name={item.name}
               displayMode="inline"
-
-
-
+              showInstallments={true}
+              showLabels={true}
+              showListPrice={false}
             />
-
-            // <MiniCartItem
-            //   {...item}
-            //   key={item.id}
-            //   large
-            //   removeItem={this.onRemoveItem}
-            //   updateItem={this.onUpdateItems}
-            //   showRemoveButton={showRemoveButton}
-            //   showSku={showSku}
-            //   enableQuantitySelector={enableQuantitySelector}
-            //   maxQuantity={maxQuantity}
-            // />
           ))}
 
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -210,7 +210,7 @@ class MiniCartContent extends Component {
         <div className={classes}>
           {items.map(item => (
 
-            <div >
+            <Fragment>
               <ExtensionPoint id="product-summary"
                 key={item.id}
                 product={this.createProductShapeFromItem(item)}
@@ -224,7 +224,7 @@ class MiniCartContent extends Component {
                 deleteButton={this.renderDeleteButton(item.id)}
                 actionOnClick={actionOnClick}
               />
-            </div>
+            </Fragment>
           ))}
 
         </div>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -159,7 +159,7 @@ class MiniCartContent extends Component {
     return (
       <div className="pa0-m">
         <Button icon variation="tertiary" onClick={e => this.onRemoveItem(id, e)}>
-          <IconDelete size={15} color="#BDBDBD" />
+          <IconDelete size={15} color="silver" />
         </Button>
       </div>
     )

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -159,6 +159,16 @@ class MiniCartContent extends Component {
     }
   }
 
+  renderDeleteButton = (id) => {
+    return (
+      <Fragment>
+        <Button icon className="pa0" variation="tertiary" onClick={(e) => this.onRemoveItem(id, e)}>
+          <IconDelete size={15} color="#BDBDBD" />
+        </Button>
+      </Fragment>
+    )
+  }
+
   renderMiniCartWithItems = (
     orderForm,
     label,
@@ -192,7 +202,6 @@ class MiniCartContent extends Component {
 
     </Fragment>
 
-
     return (
       <Fragment>
         <div className={classes}>
@@ -209,6 +218,7 @@ class MiniCartContent extends Component {
               showBorders={true}
               deleteButton={deleteButton}
             />
+
 
           ))}
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -59,8 +59,6 @@ class MiniCartContent extends Component {
 
   handleClickButton = () => location.assign('/checkout/#/cart')
 
-
-
   onRemoveItem = id => {
     this.setState({ showSpinner: true })
 
@@ -136,7 +134,7 @@ class MiniCartContent extends Component {
     </div>
   )
 
-  createProductShapeFromItem = (item) => {
+  createProductShapeFromItem = item => {
 
     return {
       productName: item.name,
@@ -157,16 +155,13 @@ class MiniCartContent extends Component {
     }
   }
 
-  renderDeleteButton = (id) => {
+  renderDeleteButton = id => {
     return (
-      <Fragment>
-        <div className="pa0-m">
-          <Button icon variation="tertiary" onClick={(e) => this.onRemoveItem(id, e)}>
-            <IconDelete size={15} color="#BDBDBD" />
-          </Button>
-        </div>
-
-      </Fragment>
+      <div className="pa0-m">
+        <Button icon variation="tertiary" onClick={e => this.onRemoveItem(id, e)}>
+          <IconDelete size={15} color="#BDBDBD" />
+        </Button>
+      </div>
     )
   }
 
@@ -204,7 +199,6 @@ class MiniCartContent extends Component {
 
     </Fragment>
 
-
     return (
       <Fragment>
         <div className={classes}>
@@ -226,11 +220,9 @@ class MiniCartContent extends Component {
               />
             </Fragment>
           ))}
-
         </div>
         <div
-          className="vtex-minicart-content__footer w-100 bg-white pa4 bt b--silver pt4 flex flex-column items-end"
-        >
+          className="vtex-minicart-content__footer w-100 bg-white pa4 bt b--silver pt4 flex flex-column items-end">
           {showDiscount && (
             <div className="vtex-minicart__content-discount blue w-100 flex justify-end items-center">
               <span className="ttl c-action-primary">{labelDiscount}</span>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -78,6 +78,8 @@ class MiniCartContent extends Component {
         orderFormId: orderForm.orderFormId,
         items: updatedItem,
       },
+    }).then(() => {
+      this.setState({ showSpinner: false })
     })
   }
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -134,26 +134,23 @@ class MiniCartContent extends Component {
     </div>
   )
 
-  createProductShapeFromItem = item => {
-
-    return {
-      productName: item.name,
-      linkText: item.detailUrl.replace(/^\//, '').replace(/\/p$/, ''),
-      sku: {
-        seller: {
-          commertialOffer: {
-            Price: item.sellingPrice,
-            ListPrice: item.ListPrice
-          }
-        },
-        name: item.skuName,
-        itemId: item.id,
-        image: {
-          imageUrl: item.imageUrl
-        },
+  createProductShapeFromItem = item => ({
+    productName: item.name,
+    linkText: item.detailUrl.replace(/^\//, '').replace(/\/p$/, ''),
+    sku: {
+      seller: {
+        commertialOffer: {
+          Price: item.sellingPrice,
+          ListPrice: item.ListPrice
+        }
       },
-    }
-  }
+      name: item.skuName,
+      itemId: item.id,
+      image: {
+        imageUrl: item.imageUrl
+      },
+    },
+  })
 
   renderMiniCartWithItems = (
     orderForm,
@@ -189,7 +186,7 @@ class MiniCartContent extends Component {
             <Fragment key={item.id}>
               <div className="relative">
                 <div className="fr absolute bottom-0 right-0">
-                  <Button icon variation="tertiary" onClick={e => this.onRemoveItem(item.id, e)}>
+                  <Button icon variation="tertiary" onClick={e => this.onRemoveItem(item.id)}>
                     <IconDelete size={15} color="silver" />
                   </Button>
                 </div>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -155,16 +155,6 @@ class MiniCartContent extends Component {
     }
   }
 
-  renderDeleteButton = id => {
-    return (
-      <div className="pa0-m">
-        <Button icon variation="tertiary" onClick={e => this.onRemoveItem(id, e)}>
-          <IconDelete size={15} color="silver" />
-        </Button>
-      </div>
-    )
-  }
-
   renderMiniCartWithItems = (
     orderForm,
     label,

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -6,9 +6,13 @@ import classNames from 'classnames'
 <<<<<<< HEAD
 =======
 import { ExtensionPoint } from 'render'
+<<<<<<< HEAD
 
 >>>>>>> Update MinicartItem para Product Summary
 import { Button, Spinner } from 'vtex.styleguide'
+=======
+import { Button, Spinner, IconDelete } from 'vtex.styleguide'
+>>>>>>> Pass deleteButton to product-summary extension point
 import ProductPrice from 'vtex.store-components/ProductPrice'
 
 import { MiniCartPropTypes } from '../propTypes'
@@ -170,7 +174,7 @@ class MiniCartContent extends Component {
     const items = this.getGroupedItems()
 
     const classes = classNames(
-      'vtex-minicart__content overflow-x-hidden',
+      'vtex-minicart__content overflow-x-hidden pa1',
       {
         'vtex-minicart__content--small bg-white': !large,
         'overflow-y-auto': large,
@@ -181,24 +185,32 @@ class MiniCartContent extends Component {
 
     const discount = this.calculateDiscount(items, orderForm.value)
     const { onClickProduct } = this.props
+    const deleteButton = <Fragment>
+      <div className="ma0 pa0 ph0"><Button icon variation="tertiary">
+        <IconDelete className="ma0 pa0 ph8" size={20} color="#BDBDBD" />
+      </Button></div>
+
+    </Fragment>
 
 
     return (
       <Fragment>
         <div className={classes}>
           {items.map(item => (
+
+
             <ExtensionPoint id="product-summary"
               key={item.id}
               product={this.createProductShapeFromItem(item)}
               name={item.name}
               displayMode="inline"
-              showInstallments={true}
-              showLabels={true}
               showListPrice={false}
+              showBadge={false}
+              showBorders={true}
+              deleteButton={deleteButton}
             />
+
           ))}
-
-
 
         </div>
         <div

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -65,7 +65,6 @@ class Sidebar extends Component {
       </OutsideClickHandler>,
       document.body
     )
-    
   }
 }
 

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -42,7 +42,7 @@ class Sidebar extends Component {
     return ReactDOM.createPortal(
       <OutsideClickHandler onOutsideClick={onOutsideClick}>
         <Animation
-          className="vtex-minicart__sidebar w-100 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
+          className="vtex-minicart__sidebar w-80 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
           isActive={isOpen}
           type="drawerLeft"
         >

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -65,6 +65,7 @@ class Sidebar extends Component {
       </OutsideClickHandler>,
       document.body
     )
+    
   }
 }
 

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -40,7 +40,7 @@ class Sidebar extends Component {
       return null
     }
 
-    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-near-black top-0 z-9999 w-100 vh-100 o-40', {
+    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-base--inverted top-0 z-9999 w-100 vh-100 o-40', {
       dn: !isOpen,
     })
 

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -5,6 +5,7 @@ import { IconCaretRight } from 'vtex.styleguide'
 import { injectIntl, intlShape } from 'react-intl'
 import OutsideClickHandler from 'react-outside-click-handler'
 import Animation from 'vtex.store-components/Animation'
+import classNames from 'classnames'
 
 import MiniCart from '../MiniCart'
 
@@ -39,8 +40,14 @@ class Sidebar extends Component {
       return null
     }
 
+    const scrimClasses = classNames('vtex-menu-sidebar__scrim fixed dim bg-near-black top-0 z-9999 w-100 vh-100 o-40', {
+      dn: !isOpen,
+    })
+
     return ReactDOM.createPortal(
       <OutsideClickHandler onOutsideClick={onOutsideClick}>
+        <div style={{ willChange: 'opacity' }} className={scrimClasses} onClick={onOutsideClick} />
+
         <Animation
           className="vtex-minicart__sidebar w-80 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-white shadow-2 flex flex-column"
           isActive={isOpen}

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -49,8 +49,7 @@ class Sidebar extends Component {
         <div style={{ willChange: 'opacity' }} className={scrimClasses} onClick={onOutsideClick} />
 
         <Animation
-                    className="vtex-minicart__sidebar w-100 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-base shadow-2 flex flex-column"
-
+          className="vtex-minicart__sidebar w-80 w-auto-ns h-100 fixed top-0 right-0 z-9999 bg-base shadow-2 flex flex-column"
           isActive={isOpen}
           type="drawerLeft"
         >


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Update the minicart sidebar to 80% of the screen and change the MinicartItem to product-summary

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Adding an extension point of product-summary in minicart/MinicartCotent.js

#### How should this be manually tested?
https://arthur--storecomponents.myvtex.com

#### Screenshots or example usage
![pr-minicart](https://user-images.githubusercontent.com/17649410/47300088-09eb0800-d5f2-11e8-92ea-74cd39debbbf.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
