### PR TITLE
Use filled icons from IconPack instead local icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Use icons from the dreamstore icon pack.
-  
-  
+
 ## [1.2.3] - 2018-11-07
 ### Changed
 - Close the `SideBar` after clicking some product's link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Use icons from the dreamstore icon pack.
+  
+  
 ## [1.2.3] - 2018-11-07
 ### Changed
 - Close the `SideBar` after clicking some product's link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.0] - 2018-11-21
 ### Changed
 - Use icons from the dreamstore icon pack.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/images/CartIcon.js
+++ b/react/images/CartIcon.js
@@ -1,28 +1,35 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 /**
  * Cart Icon component in svg
  */
-export default class CartIcon extends Component {
-  static propTypes = {
-    /* Percentage size of the icon */
-    size: PropTypes.number,
-  }
-
-  static defaultProps = {
-    size: 20,
-  }
-
-  render() {
-    const { size } = this.props
-    return (
-      <svg width={size} height={size} viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0 0H8L10.6667 24H34.6667L40 8H16" transform="translate(2 2)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(10 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(31.3335 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    )
-  }
+const CartIcon = ({ size, fillColor }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      width={size}
+      height={size}
+      viewBox="0 0 22 22"
+      fill="none"
+      color={fillColor}
+    >
+      <use href="#minicart" xlinkHref="#minicart" />
+    </svg>
+  )
 }
 
+CartIcon.propTypes = {
+  /* Percentage size of the icon */
+  size: PropTypes.number,
+  /* Fill color for the icon */
+  fillColor: PropTypes.string,
+}
+
+CartIcon.defaultProps = {
+  size: 20,
+  fillColor: 'currentColor',
+}
+
+export default CartIcon


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
By design requirement it is necessary to use filled icons instead of the outline icons.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Using icons from `vtex.styleguide`

#### How should this be manually tested?
https://filled--storecomponents.myvtex.com/

#### Screenshots or example usage
![frame_2](https://user-images.githubusercontent.com/17649410/48708701-042d1600-ebe2-11e8-9220-caf34f3b4a1f.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
