### PR TITLE
Use SVG paths for cart icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.1] - 2018-11-27
 ### Changed
 - Replace cart icon from icon pack with svg paths in `1.x`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace icons from icon with pure svg pack in `1.x`.
 
 ## [1.3.0] - 2018-11-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Replace icons from icon with pure svg pack in `1.x`.
+- Replace cart icon from icon pack with svg paths in `1.x`.
 
 ## [1.3.0] - 2018-11-21
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/images/CartIcon.js
+++ b/react/images/CartIcon.js
@@ -4,18 +4,12 @@ import PropTypes from 'prop-types'
 /**
  * Cart Icon component in svg
  */
-const CartIcon = ({ size, fillColor }) => {
+const CartIcon = ({ size }) => {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-      width={size}
-      height={size}
-      viewBox="0 0 22 22"
-      fill="none"
-      color={fillColor}
-    >
-      <use href="#minicart" xlinkHref="#minicart" />
+    <svg width={size} height={size} viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M0 0H8L10.6667 24H34.6667L40 8H16" transform="translate(2 2)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(10 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M8 4C8 6.20914 6.20914 8 4 8C1.79086 8 0 6.20914 0 4C0 1.79086 1.79086 0 4 0C6.20914 0 8 1.79086 8 4Z" transform="translate(31.3335 34)" stroke="currentColor" strokeWidth="3" strokeMiterlimit="10" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   )
 }
@@ -23,13 +17,10 @@ const CartIcon = ({ size, fillColor }) => {
 CartIcon.propTypes = {
   /* Percentage size of the icon */
   size: PropTypes.number,
-  /* Fill color for the icon */
-  fillColor: PropTypes.string,
 }
 
 CartIcon.defaultProps = {
   size: 20,
-  fillColor: 'currentColor',
 }
 
 export default CartIcon


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Use old icons, because that change should be only in v2.x
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The cart icon wasn't being shown.
#### How should this be manually tested?
[workspace](https://fixcarticon--storecomponents.myvtex.com/)
#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
