### PR TITLE
Update the CSS module classes' name to be in CamelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.3] - 2018-12-14
 ### Changed
 - CSS module classes' name to be in CamelCase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CSS module classes' name to be in CamelCase.
 
 ## [2.1.2] - 2018-12-12
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import ContentLoader from 'react-content-loader'
 
 import minicart from '../minicart.css'
+
 export default class Image extends Component {
   constructor(props) {
     super(props)
@@ -24,7 +25,7 @@ export default class Image extends Component {
       height={100}
       width={100}
     >
-      <rect className={`${minicart.item__imageLoader}`} />
+      <rect className={`${minicart.itemImageLoader}`} />
     </ContentLoader>
   )
 
@@ -34,7 +35,7 @@ export default class Image extends Component {
     return (
       <Fragment>
         <img
-          className={`${minicart.item__image} w-auto h-100`}
+          className={`${minicart.itemImage} w-auto h-100`}
           onLoad={() => this.setState({ isLoaded: true })}
           src={this.stripImageUrl(url)} alt={alt}
         />

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -238,7 +238,7 @@ class MiniCartContent extends Component {
 
         <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end`}>
           {showDiscount && discount > 0 && (
-            <div className={`${minicart.content__discount} w-100 flex justify-end items-center`}>
+            <div className={`${minicart.contentDiscount} w-100 flex justify-end items-center`}>
               <span className="ttl c-action-primary">{labelDiscount}</span>
               <ProductPrice
                 sellingPrice={discount}
@@ -248,7 +248,7 @@ class MiniCartContent extends Component {
               />
             </div>
           )}
-          <div className={`${minicart.content__price} mb3`}>
+          <div className={`${minicart.contentPrice} mb3`}>
             {this.isUpdating
               ? (<Spinner size={18} />)
               : (

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -193,7 +193,7 @@ class MiniCartContent extends Component {
     const classes = classNames(
       `${minicart.content} overflow-x-hidden pa1`,
       {
-        [`${minicart.content__small} bg-base`]: !large,
+        [`${minicart.contentSmall} bg-base`]: !large,
         'overflow-y-auto': large,
         'overflow-y-scroll': items.length > 3 && !large,
         'overflow-y-hidden': items.length <= 3 && !large,
@@ -236,7 +236,7 @@ class MiniCartContent extends Component {
           ))}
         </div>
 
-        <div className={`${minicart.content__footer} w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end`}>
+        <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end`}>
           {showDiscount && discount > 0 && (
             <div className={`${minicart.content__discount} w-100 flex justify-end items-center`}>
               <span className="ttl c-action-primary">{labelDiscount}</span>

--- a/react/components/MiniCartItem.js
+++ b/react/components/MiniCartItem.js
@@ -87,8 +87,8 @@ export default class MiniCartItem extends Component {
 
     const { isRemovingItem } = this.state
 
-    const nameClasses = classNames(`${minicart.item__name} h2 mb3`, {
-      [`${minicart.item__name__large}`]: showRemoveButton,
+    const nameClasses = classNames(`${minicart.itemName} h2 mb3`, {
+      [`${minicart.itemNameLarge}`]: showRemoveButton,
     })
 
     return (
@@ -105,8 +105,8 @@ export default class MiniCartItem extends Component {
                 showSku={showSku}
               />
             </div>
-            <div className={`${minicart.item__footer} relative flex flex-row pb2 items-center w-100`}>
-              <div className={`${minicart.img__container} h3 w3 mw3`}>
+            <div className={`${minicart.itemFooter} relative flex flex-row pb2 items-center w-100`}>
+              <div className={`${minicart.imgContainer} h3 w3 mw3`}>
                 <Image url={imageUrl} alt={name} />
               </div>
               <div className="absolute right-0 bottom-0 mb1">
@@ -138,7 +138,7 @@ export default class MiniCartItem extends Component {
           )}
           {(showRemoveButton && isRemovingItem) && (
             <div
-              className={`${minicart.item__removeBtn} absolute right-0 top-0 flex items-center justify-center mt3 mr4`}
+              className={`${minicart.itemRemoveBtn} absolute right-0 top-0 flex items-center justify-center mt3 mr4`}
             >
               <Spinner size={20} />
             </div>

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -10,7 +10,7 @@ import classNames from 'classnames'
 import MiniCart from '../MiniCart'
 import minicart from '../minicart.css'
 
-const OPEN_SIDEBAR_CLASS = minicart.sidebar__open
+const OPEN_SIDEBAR_CLASS = minicart.sidebarOpen
 
 /* SideBar component */
 class Sidebar extends Component {

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -41,7 +41,7 @@ class Sidebar extends Component {
       return null
     }
 
-    const scrimClasses = classNames(`${minicart.sidebar__scrim} fixed dim bg-base--inverted top-0 left-0 z-9999 w-100 vh-100 o-40`, {
+    const scrimClasses = classNames(`${minicart.sidebarScrim} fixed dim bg-base--inverted top-0 left-0 z-9999 w-100 vh-100 o-40`, {
       dn: !isOpen,
     })
 
@@ -54,7 +54,7 @@ class Sidebar extends Component {
           isActive={isOpen}
           type="drawerLeft"
         >
-          <div className={`${minicart.sidebar__header} pointer flex flex-row items-center pa5 h3 bg-base w-100 z-max bb b--muted-3 bw1`}>
+          <div className={`${minicart.sidebarHeader} pointer flex flex-row items-center pa5 h3 bg-base w-100 z-max bb b--muted-3 bw1`}>
             <div
               className="c-muted-1 pa4 flex items-center"
               onClick={onOutsideClick}

--- a/react/minicart.css
+++ b/react/minicart.css
@@ -1,4 +1,4 @@
-.content__small {
+.contentSmall {
   max-height: 383px;
 }
 
@@ -16,17 +16,17 @@
   top: 100%;
 }
 
-.item_imageLoader {
+.itemImageLoader {
   width: 100%;
   height: 100%;
 }
 
-.content__footer {
+.contentFooter {
   margin-top: auto;
 }
 
 @media only screen and (max-width: 40rem) {
-  body.sidebar__open {
+  body.sidebarOpen {
     overflow: hidden;
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the CSS module classes' name to be in CamelCase.

#### What problem is this solving?
The classes' name was not following a pattern.

#### How should this be manually tested?
[Click here to access the workspace.](https://waza--storecomponents.myvtex.com/)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
