### PR TITLE
Fix minimum items length to scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Change minimum items length to scrolling
 
 ## [2.1.3] - 2018-12-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.4] - 2018-12-14
 ### Fixed
 - Fix minimum items length to scrolling in minicart.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Change minimum items length to scrolling.
+- Fix minimum items length to scrolling in minicart.
 
 ## [2.1.3] - 2018-12-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Change minimum items length to scrolling
+- Change minimum items length to scrolling.
 
 ## [2.1.3] - 2018-12-14
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -195,8 +195,8 @@ class MiniCartContent extends Component {
       {
         [`${minicart.contentSmall} bg-base`]: !large,
         'overflow-y-auto': large,
-        'overflow-y-scroll': items.length > 3 && !large,
-        'overflow-y-hidden': items.length <= 3 && !large,
+        'overflow-y-scroll': items.length > 2 && !large,
+        'overflow-y-hidden': items.length <= 2 && !large,
       }
     )
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -189,14 +189,15 @@ class MiniCartContent extends Component {
     large
   ) => {
     const items = this.props.data.orderForm.items
+    const MIN_ITEMS_TO_SCROLL = 2
 
     const classes = classNames(
       `${minicart.content} overflow-x-hidden pa1`,
       {
         [`${minicart.contentSmall} bg-base`]: !large,
         'overflow-y-auto': large,
-        'overflow-y-scroll': items.length > 2 && !large,
-        'overflow-y-hidden': items.length <= 2 && !large,
+        'overflow-y-scroll': items.length > MIN_ITEMS_TO_SCROLL && !large,
+        'overflow-y-hidden': items.length <= MIN_ITEMS_TO_SCROLL && !large,
       }
     )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix minimum items length to scrolling in minicart.

#### What problem is this solving?

When the minicart has 3 items, they dont properly fit on the minicart's container.  

#### How should this be manually tested?

[Access this workspace](https://orderby--storecomponents.myvtex.com)

#### Screenshots or example usage
![orderby--storecomponents myvtex com_ 1](https://user-images.githubusercontent.com/10901554/49966670-d187ec00-ff07-11e8-86b9-cdc5b15a738b.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
