### PR TITLE
separate attachs and parent items in orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Create `groupItemsWithParents` function, add tests. Group parent items with its attachments.
 
 ## [2.2.0] - 2018-12-17
 ### Added

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -8,6 +8,7 @@ import { MiniCartPropTypes } from './propTypes'
 import Sidebar from './components/Sidebar'
 import Popup from './components/Popup'
 import { orderFormConsumer } from 'vtex.store/OrderFormContext'
+import { isParentItem } from './utils/itemsHelper'
 
 import minicart from './minicart.css'
 
@@ -65,7 +66,6 @@ export class MiniCart extends Component {
   get itemsQuantity() {
     const { orderFormContext: { orderForm }} = this.props
     if (!orderForm || !orderForm.items) return 0
-    const isParentItem = ({ parentItemIndex, parentAssemblyBinding }) => parentItemIndex == null && parentAssemblyBinding == null
     return orderForm.items.filter(isParentItem).length
   }
 

--- a/react/MiniCart.js
+++ b/react/MiniCart.js
@@ -61,6 +61,13 @@ export class MiniCart extends Component {
       to: detailUrl
     })
   }
+  
+  get itemsQuantity() {
+    const { orderFormContext: { orderForm }} = this.props
+    if (!orderForm || !orderForm.items) return 0
+    const isParentItem = ({ parentItemIndex, parentAssemblyBinding }) => parentItemIndex == null && parentAssemblyBinding == null
+    return orderForm.items.filter(isParentItem).length
+  }
 
   render() {
     const { openContent } = this.state
@@ -81,8 +88,7 @@ export class MiniCart extends Component {
       hideContent,
     } = this.props
 
-    const { orderForm } = orderFormContext
-    const quantity = orderForm && orderForm.items ? orderForm.items.length : 0
+    const quantity = this.itemsQuantity
 
     const large =
       (type && type === 'sidebar') ||

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -1,13 +1,14 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
-import { reduceBy, values, clone, partition } from 'ramda'
+import { reduceBy, values, clone } from 'ramda'
 import classNames from 'classnames'
 import { ExtensionPoint } from 'render'
 import { Button, Spinner, IconDelete } from 'vtex.styleguide'
 import ProductPrice from 'vtex.store-components/ProductPrice'
 import { MiniCartPropTypes } from '../propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
+import { groupItemsWithParents } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
 
@@ -53,25 +54,6 @@ class MiniCartContent extends Component {
         this.props.data.orderForm.items
       )
     )
-
-  itemWithOptions = (groupedItems) => {
-    const isParentItem = ({ parentItemIndex, parentAssemblyBinding }) => parentItemIndex == null && parentAssemblyBinding == null
-    const [parentItems, options] = partition(isParentItem, groupedItems)
-
-    const parentMap = parentItems.reduce((prev, curr) => ({ ...prev, [curr.id]: { ...curr, addedOptions: [] } }),{})
-    return values(
-      options.reduce((prev, curr) => {
-        const { parentItemIndex } = curr
-        const parentId = this.props.data.orderForm.items[parentItemIndex].id
-        const parentObj = prev[parentId]
-        parentObj.addedOptions.push({ ...curr })
-        return { 
-          ...prev,
-          [parentId]: parentObj,
-        }
-      }, parentMap)
-    )
-  }
 
   calculateDiscount = (items, totalPrice) =>
     this.sumItemsPrice(items) - totalPrice
@@ -208,7 +190,7 @@ class MiniCartContent extends Component {
     isUpdating,
     large
   ) => {
-    const items = this.itemWithOptions(this.props.data.orderForm.items)
+    const items = groupItemsWithParents(this.props.data.orderForm)
     const MIN_ITEMS_TO_SCROLL = 2
 
     const classes = classNames(

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
-import { reduceBy, values, clone, partition, map, prop } from 'ramda'
+import { reduceBy, values, clone, partition } from 'ramda'
 import classNames from 'classnames'
 import { ExtensionPoint } from 'render'
 import { Button, Spinner, IconDelete } from 'vtex.styleguide'
@@ -185,6 +185,7 @@ class MiniCartContent extends Component {
         imageUrl: changeImageUrlSize(toHttps(item.imageUrl), 240),
       },
     },
+    addedOptions: (item.addedOptions || []).map(option => this.createProductShapeFromItem(option)),
   })
 
   get isUpdating() {

--- a/react/utils/__mocks__/orderForm.json
+++ b/react/utils/__mocks__/orderForm.json
@@ -1,0 +1,581 @@
+{  
+  "items":[  
+     {  
+        "additionalInfo":{  
+           "dimension":{  
+              "cubicweight":1,
+              "height":1,
+              "length":1,
+              "weight":1,
+              "width":1
+           },
+           "categoriesIds":"/4/",
+           "productClusterId":"137",
+           "commercialConditionId":"1",
+           "brandName":"Pizza",
+           "brandId":"2000004",
+           "offeringInfo":null,
+           "offeringType":null,
+           "offeringTypeId":null
+        },
+        "sellerSku":"17",
+        "priceTable":null,
+        "priceValidUntil":"2019-12-12T18:01:08.3149595Z",
+        "callCenterOperator":null,
+        "commission":0,
+        "freightCommission":0,
+        "taxCode":"",
+        "uniqueId":"63D1D478FCD54263A5CB5A75634A8A90",
+        "id":"17",
+        "productId":"13",
+        "refId":"1111",
+        "ean":null,
+        "name":"Pepperoni Small",
+        "skuName":"Small",
+        "modalType":null,
+        "parentItemIndex":null,
+        "parentAssemblyBinding":null,
+        "tax":0,
+        "priceDefinitions":{  
+           "listPrice":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ],
+           "price":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ],
+           "sellingPrice":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ]
+        },
+        "price":1490,
+        "listPrice":1490,
+        "manualPrice":null,
+        "sellingPrice":1490,
+        "orderRewardStatus":"invoiced",
+        "rewardValue":0,
+        "isGift":false,
+        "preSaleDate":null,
+        "productCategoryIds":"/4/",
+        "productCategories":{  
+           "4":"Pizzas"
+        },
+        "quantity":1,
+        "seller":"1",
+        "sellerChain":[  
+           "1"
+        ],
+        "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155439-55-55/pepperoni-feast.0e1c4c9e7b8900d08cc51ff285fd9ae3.1.jpg?v=636770441237070000",
+        "detailUrl":"/pizza-pepperoni/p",
+        "components":[  
+
+        ],
+        "bundleItems":[  
+
+        ],
+        "attachments":[  
+
+        ],
+        "attachmentOfferings":[  
+
+        ],
+        "offerings":[  
+
+        ],
+        "priceTags":[  
+
+        ],
+        "availability":"available",
+        "measurementUnit":"un",
+        "unitMultiplier":1
+     },
+     {  
+        "additionalInfo":{  
+           "dimension":{  
+              "cubicweight":1,
+              "height":1,
+              "length":1,
+              "weight":1,
+              "width":1
+           },
+           "categoriesIds":"/4/7/",
+           "productClusterId":"137",
+           "commercialConditionId":"1",
+           "brandName":"Pizza",
+           "brandId":"2000004",
+           "offeringInfo":null,
+           "offeringType":null,
+           "offeringTypeId":null
+        },
+        "sellerSku":"14",
+        "priceTable":"small",
+        "priceValidUntil":"2019-12-12T18:01:08.3149595Z",
+        "callCenterOperator":null,
+        "commission":0,
+        "freightCommission":0,
+        "taxCode":"",
+        "uniqueId":"E569EA554E754EA78BDF1FEB51E1E14C",
+        "id":"14",
+        "productId":"12",
+        "refId":"14",
+        "ean":null,
+        "name":"Classic Crust",
+        "skuName":"Classic Crust",
+        "modalType":null,
+        "parentItemIndex":0,
+        "parentAssemblyBinding":"Pepperoni - Small_Crust",
+        "tax":0,
+        "priceDefinitions":{  
+           "listPrice":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ],
+           "price":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ],
+           "sellingPrice":[  
+              {  
+                 "value":1490,
+                 "quantity":1
+              }
+           ]
+        },
+        "price":1490,
+        "listPrice":1490,
+        "manualPrice":null,
+        "sellingPrice":1490,
+        "orderRewardStatus":"invoiced",
+        "rewardValue":0,
+        "isGift":false,
+        "preSaleDate":null,
+        "productCategoryIds":"/4/7/",
+        "productCategories":{  
+           "4":"Pizzas",
+           "7":"Crust"
+        },
+        "quantity":1,
+        "seller":"1",
+        "sellerChain":[  
+           "1"
+        ],
+        "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155413-55-55/classic.png?v=636759866429100000",
+        "detailUrl":"/classic-crust/p",
+        "components":[  
+
+        ],
+        "bundleItems":[  
+
+        ],
+        "attachments":[  
+
+        ],
+        "attachmentOfferings":[  
+
+        ],
+        "offerings":[  
+
+        ],
+        "priceTags":[  
+
+        ],
+        "availability":"available",
+        "measurementUnit":"un",
+        "unitMultiplier":1
+     },
+     {  
+        "additionalInfo":{  
+           "dimension":{  
+              "cubicweight":1,
+              "height":1,
+              "length":1,
+              "weight":1,
+              "width":1
+           },
+           "categoriesIds":"/4/6/",
+           "productClusterId":"137",
+           "commercialConditionId":"1",
+           "brandName":"Pizza",
+           "brandId":"2000004",
+           "offeringInfo":null,
+           "offeringType":null,
+           "offeringTypeId":null
+        },
+        "sellerSku":"9",
+        "priceTable":"basic",
+        "priceValidUntil":"2019-12-12T18:01:08.3149595Z",
+        "callCenterOperator":null,
+        "commission":0,
+        "freightCommission":0,
+        "taxCode":"",
+        "uniqueId":"59E1B1B5E767465298420E212C91A250",
+        "id":"9",
+        "productId":"7",
+        "refId":"3",
+        "ean":null,
+        "name":"Pepperoni",
+        "skuName":"Pepperoni",
+        "modalType":null,
+        "parentItemIndex":0,
+        "parentAssemblyBinding":"Pepperoni - Small_Basic Toppings",
+        "tax":0,
+        "priceDefinitions":{  
+           "listPrice":[  
+              {  
+                 "value":0,
+                 "quantity":1
+              }
+           ],
+           "price":[  
+              {  
+                 "value":0,
+                 "quantity":1
+              }
+           ],
+           "sellingPrice":[  
+              {  
+                 "value":0,
+                 "quantity":1
+              }
+           ]
+        },
+        "price":0,
+        "listPrice":0,
+        "manualPrice":null,
+        "sellingPrice":0,
+        "orderRewardStatus":"invoiced",
+        "rewardValue":0,
+        "isGift":false,
+        "preSaleDate":null,
+        "productCategoryIds":"/4/6/",
+        "productCategories":{  
+           "4":"Pizzas",
+           "6":"Toppings"
+        },
+        "quantity":1,
+        "seller":"1",
+        "sellerChain":[  
+           "1"
+        ],
+        "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155428-55-55/Topping_Pepperoni.jpg.png?v=636766047561270000",
+        "detailUrl":"/pepperoni/p",
+        "components":[  
+
+        ],
+        "bundleItems":[  
+
+        ],
+        "attachments":[  
+
+        ],
+        "attachmentOfferings":[  
+
+        ],
+        "offerings":[  
+
+        ],
+        "priceTags":[  
+
+        ],
+        "availability":"available",
+        "measurementUnit":"un",
+        "unitMultiplier":1
+     }
+  ],
+  "sellers":[  ],
+  "giftRegistryData":null,
+  "receiptData":{  },
+  "contextData":{  
+     "loggedIn":false,
+     "hasAccessToOrderFormEnabledByLicenseManager":false,
+     "userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
+     "userId":""
+  },
+  "marketPlaceOrderId":"",
+  "marketPlaceOrderGroup":null,
+  "marketplaceServicesEndpoint":null,
+  "orderFormId":"e512a5d7681a4fdcb5094bfc0c79e5e5",
+  "sequence":"500170",
+  "affiliateId":"",
+  "status":"",
+  "callCenterOperator":"",
+  "userProfileId":"76428d54-a18e-40f3-92d8-3c599474353a",
+  "hostName":"delivery",
+  "creationVersion":"2.155.18.3152",
+  "creationEnvironment":"BETA",
+  "lastChangeVersion":"2.155.18.3152",
+  "workflowInstanceId":"B6422F3E7EB344A1A872B3FB5DDA39E3",
+  "marketplacePaymentValue":null,
+  "orderId":"882980123840-01",
+  "orderGroup":"882980123840",
+  "state":"on-order-completed",
+  "isCheckedIn":false,
+  "sellerOrderId":"00-882980123840-01",
+  "storeId":null,
+  "checkedInPickupPointId":null,
+  "value":2980,
+  "totals":[  ],
+  "clientProfileData":{  },
+  "ratesAndBenefitsData":{  },
+  "shippingData":{  },
+  "paymentData":{  },
+  "clientPreferencesData":{  },
+  "commercialConditionData":null,
+  "marketingData":null,
+  "storePreferencesData":{  },
+  "openTextField":null,
+  "invoiceData":null,
+  "itemMetadata":{  
+     "items":[  
+        {  
+           "id":"17",
+           "name":"Pepperoni Small",
+           "skuName":"Small",
+           "productId":"13",
+           "refId":"1111",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155439-55-55/pepperoni-feast.0e1c4c9e7b8900d08cc51ff285fd9ae3.1.jpg?v=636770441237070000",
+           "detailUrl":"/pizza-pepperoni/p",
+           "assemblyOptions":[  
+              {  
+                 "id":"Pepperoni - Small_Crust",
+                 "name":"Pepperoni - Small",
+                 "required":true,
+                 "inputValues":{  
+
+                 },
+                 "composition":{  
+                    "minQuantity":1,
+                    "maxQuantity":1,
+                    "items":[  
+                       {  
+                          "id":"14",
+                          "minQuantity":1,
+                          "maxQuantity":1,
+                          "priceTable":"small"
+                       }
+                    ]
+                 }
+              },
+              {  
+                 "id":"Pepperoni - Small_Toppings",
+                 "name":"Pepperoni - Small",
+                 "required":true,
+                 "inputValues":{  
+
+                 },
+                 "composition":{  
+                    "minQuantity":0,
+                    "maxQuantity":10,
+                    "items":[  
+                       {  
+                          "id":"8",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"9",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"10",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"11",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"36",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"37",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       },
+                       {  
+                          "id":"38",
+                          "minQuantity":0,
+                          "maxQuantity":3,
+                          "priceTable":"small"
+                       }
+                    ]
+                 }
+              },
+              {  
+                 "id":"Pepperoni - Small_Basic Toppings",
+                 "name":"Pepperoni - Small",
+                 "required":true,
+                 "inputValues":{  
+
+                 },
+                 "composition":{  
+                    "minQuantity":1,
+                    "maxQuantity":2,
+                    "items":[  
+                       {  
+                          "id":"9",
+                          "minQuantity":1,
+                          "maxQuantity":1,
+                          "priceTable":"basic"
+                       },
+                       {  
+                          "id":"11",
+                          "minQuantity":0,
+                          "maxQuantity":1,
+                          "priceTable":"basic"
+                       }
+                    ]
+                 }
+              }
+           ]
+        },
+        {  
+           "id":"14",
+           "name":"Classic Crust",
+           "skuName":"Classic Crust",
+           "productId":"12",
+           "refId":"14",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155413-55-55/classic.png?v=636759866429100000",
+           "detailUrl":"/classic-crust/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"8",
+           "name":"Ham",
+           "skuName":"Ham",
+           "productId":"6",
+           "refId":"2",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155432-55-55/Topping_Jamon.jpg.png?v=636766052579200000",
+           "detailUrl":"/ham/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"9",
+           "name":"Pepperoni",
+           "skuName":"Pepperoni",
+           "productId":"7",
+           "refId":"3",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155428-55-55/Topping_Pepperoni.jpg.png?v=636766047561270000",
+           "detailUrl":"/pepperoni/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"10",
+           "name":"Champignon",
+           "skuName":"Champignon",
+           "productId":"8",
+           "refId":"4",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155436-55-55/Topping_Champinones.png?v=636766057405600000",
+           "detailUrl":"/champignon/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"11",
+           "name":"Onion",
+           "skuName":"Onion",
+           "productId":"9",
+           "refId":"5",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155427-55-55/Topping_Cebolla.jpg.png?v=636766046799500000",
+           "detailUrl":"/onion/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"36",
+           "name":"Black Olives",
+           "skuName":"Black Olives",
+           "productId":"23",
+           "refId":"151113",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155430-55-55/Topping_Aceitunas-Negras.jpg.png?v=636766049376970000",
+           "detailUrl":"/black-olives/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"37",
+           "name":"Green Pepper",
+           "skuName":"Green Pepper",
+           "productId":"24",
+           "refId":"123123",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155431-55-55/PIMIENTO-VERDE.png?v=636766050771230000",
+           "detailUrl":"/green-pepper/p",
+           "assemblyOptions":[  
+
+           ]
+        },
+        {  
+           "id":"38",
+           "name":"Pineapple",
+           "skuName":"Pineapple",
+           "productId":"25",
+           "refId":"121211",
+           "ean":null,
+           "imageUrl":"http://delivery.vteximg.com.br/arquivos/ids/155435-55-55/Topping_Pina.jpg.png?v=636766056177370000",
+           "detailUrl":"/pineapple/p",
+           "assemblyOptions":[  
+
+           ]
+        }
+     ]
+  },
+  "taxData":null,
+  "customData":null,
+  "hooksData":null,
+  "changeData":null,
+  "subscriptionData":null,
+  "salesChannel":"1",
+  "followUpEmail":"b9d92e2fd6b1447385c14d836594ae4d@ct.vtex.com.br",
+  "creationDate":"2018-12-12T18:02:18.0240352Z",
+  "lastChange":"2018-12-12T18:02:30.1917395Z",
+  "timeZoneCreationDate":"2018-12-12T16:02:18.0240352",
+  "timeZoneLastChange":"2018-12-12T16:02:30.1917395",
+  "isCompleted":true,
+  "merchantName":null,
+  "userType":"",
+  "roundingError":0,
+  "allowEdition":false,
+  "allowCancellation":true,
+  "isUserDataVisible":false,
+  "allowChangeSeller":false
+}

--- a/react/utils/__tests__/itemsHelper.test.js
+++ b/react/utils/__tests__/itemsHelper.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+import { isParentItem, groupItemsWithParents } from '../itemsHelper'
+import orderForm from '../__mocks__/orderForm.json'
+
+it('should return only items that dont have parent', () => {
+  const parentItems = orderForm.items.filter(isParentItem)
+  expect(parentItems.length).toBe(1)
+})
+
+it('should group items and its attachments', () => {
+  const items = orderForm.items
+  const itemsWithOptions = groupItemsWithParents(orderForm)
+  const parentItemsCount = itemsWithOptions.length
+  const addedOptionsCount = 
+    itemsWithOptions.reduce((prev, curr) => prev + curr.addedOptions.length, 0)
+  expect(parentItemsCount).toBe(1)
+  expect(addedOptionsCount).toBe(2)
+
+  // Test if all orderForm items are present either as parents or as added options
+  expect(parentItemsCount + addedOptionsCount).toBe(items.length)
+})
+

--- a/react/utils/itemsHelper.js
+++ b/react/utils/itemsHelper.js
@@ -1,0 +1,22 @@
+import { values, partition } from 'ramda'
+
+export const isParentItem = 
+  ({ parentItemIndex, parentAssemblyBinding }) => parentItemIndex == null && parentAssemblyBinding == null
+
+export const groupItemsWithParents = (orderForm) => {
+  const [parentItems, options] = partition(isParentItem, orderForm.items)
+
+  const parentMap = parentItems.reduce((prev, curr) => ({ ...prev, [curr.id]: { ...curr, addedOptions: [] } }),{})
+  return values(
+    options.reduce((prev, currOption) => {
+      const { parentItemIndex } = currOption
+      const parentId = orderForm.items[parentItemIndex].id
+      const parentObj = prev[parentId]
+      parentObj.addedOptions.push({ ...currOption })
+      return { 
+        ...prev,
+        [parentId]: parentObj,
+      }
+    }, parentMap)
+  )
+}


### PR DESCRIPTION
DISCLAIMER: os campos até agora só aparecem em checkout BETA
#### What is the purpose of this pull request?

Agora, badge mostra apenas o número de itens que não são attachments.

Também, foi criado uma função que particiona e agrupa os itens.

Assim, como mostrado na figura o vetor `items` são os items pai e cada items passa a ter um campo `addedOptions` que aí no `product-summary` tem que ser feito um esforço para mostrar as options

<img width="168" alt="screen shot 2018-12-26 at 15 37 07" src="https://user-images.githubusercontent.com/4925068/50453084-4fdf8780-0925-11e9-9fa1-1216ee7cd6ee.png">
<img width="595" alt="screen shot 2018-12-26 at 15 37 11" src="https://user-images.githubusercontent.com/4925068/50453085-4fdf8780-0925-11e9-81b6-d664d2477fb2.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
