### PR TITLE
Replace image URL just for legacy file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Replace URL just for legacy file manager url format.
 
 ## [2.3.1] - 2019-01-04
 ### Fixed
@@ -24,8 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.1.5] - 2018-12-14
 ### Changed
-- Bump major version of `vtex.styleguide` and `vtex.store-components`. 
-- Add design tokens on selling price label. 
+- Bump major version of `vtex.styleguide` and `vtex.store-components`.
+- Add design tokens on selling price label.
 
 ## [2.1.4] - 2018-12-14
 ### Fixed
@@ -195,7 +197,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `Popup` to appear when the `MiniCart` button is clicked instead of on hover.
 
-### Fixed 
+### Fixed
 - `maxQuantity` undefined warning.
 - Loading mixed (insecure) display content warning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.2] - 2019-01-09
 ### Fixed
 - Replace URL just for legacy file manager url format.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "defaultLocale": "pt-BR",
   "builders": {
     "pages": "0.x",

--- a/react/utils/urlHelpers.js
+++ b/react/utils/urlHelpers.js
@@ -4,13 +4,17 @@ export const MAX_WIDTH = 3000
 export const MAX_HEIGHT = 4000
 
 /**
- * Having the url below as base,
+ * Having the url below as base for the LEGACY file manager,
  * https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000
  * the following regex will match https://storecomponents.vteximg.com.br/arquivos/ids/155472
  *
  * Also matches urls with defined sizes like:
  * https://storecomponents.vteximg.com.br/arquivos/ids/155473-160-auto
  * @type {RegExp}
+ *
+ * On the new vtex.file-manager isn't necessary replace the URL, just add the param on the querystring, like:
+ * "?width=WIDTH&height=HEIGHT&aspect=true"
+ *
  */
 const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
 
@@ -25,6 +29,13 @@ export function cleanImageUrl(imageUrl) {
   if (result.length > 0) return result[0]
 }
 
+function replaceLegacyFileManager(imageUrl, width, height) {
+  if (!imageUrl.includes('/arquivos/ids/')) return imageUrl
+  imageUrl = cleanImageUrl(imageUrl)
+  imageUrl = `${imageUrl}-${width}-${height}`
+  return imageUrl
+}
+
 export function changeImageUrlSize(
   imageUrl,
   width = DEFAULT_WIDTH,
@@ -34,7 +45,8 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = cleanImageUrl(imageUrl)
+  imageUrl = replaceLegacyFileManager(imageUrl, width, height)
+  imageUrl = `${imageUrl}${imageUrl.split('?')[1] ? '&' : '?'}width=${width}&height=${height}&aspect=true`
 
-  return `${imageUrl}-${width}-${height}`
+  return imageUrl
 }

--- a/react/utils/urlHelpers.js
+++ b/react/utils/urlHelpers.js
@@ -29,8 +29,10 @@ export function cleanImageUrl(imageUrl) {
   if (result.length > 0) return result[0]
 }
 
-function replaceLegacyFileManager(imageUrl, width, height) {
-  if (!imageUrl.includes('/arquivos/ids/')) return imageUrl
+function replaceLegacyFileManagerUrl(imageUrl, width, height) {
+  const legacyUrlPattern = '/arquivos/ids/'
+  const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
+  if (!isLegacyUrl) return imageUrl
   imageUrl = cleanImageUrl(imageUrl)
   imageUrl = `${imageUrl}-${width}-${height}`
   return imageUrl
@@ -45,8 +47,9 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = replaceLegacyFileManager(imageUrl, width, height)
-  imageUrl = `${imageUrl}${imageUrl.split('?')[1] ? '&' : '?'}width=${width}&height=${height}&aspect=true`
+  imageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
+  const queryStringSeparator = imageUrl.includes('?') ? '&' : '?'
+  imageUrl = `${imageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
 
   return imageUrl
 }

--- a/react/utils/urlHelpers.js
+++ b/react/utils/urlHelpers.js
@@ -33,9 +33,7 @@ function replaceLegacyFileManagerUrl(imageUrl, width, height) {
   const legacyUrlPattern = '/arquivos/ids/'
   const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
   if (!isLegacyUrl) return imageUrl
-  imageUrl = cleanImageUrl(imageUrl)
-  imageUrl = `${imageUrl}-${width}-${height}`
-  return imageUrl
+  return `${cleanImageUrl(imageUrl)}-${width}-${height}`
 }
 
 export function changeImageUrlSize(
@@ -47,9 +45,8 @@ export function changeImageUrlSize(
   typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
   typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
 
-  imageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
-  const queryStringSeparator = imageUrl.includes('?') ? '&' : '?'
-  imageUrl = `${imageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
+  const normalizedImageUrl = replaceLegacyFileManagerUrl(imageUrl, width, height)
+  const queryStringSeparator = normalizedImageUrl.includes('?') ? '&' : '?'
 
-  return imageUrl
+  return `${normalizedImageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The new **vtex.file-manager** uses querystring for image resize, so when you try to make the replace on the new system, you get an error.

We try to find the version of file-manager into the URL path, and replace when needed.
For all the others cases, the querystring is added to handle the new format and without breaking the old.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
