### PR TITLE
Fix/price overlapping mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.3] - 2019-01-15
 ### Fixed
 - Fixed price overlapping in the mobile view.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed price overlapping in the mobile view.
 
 ## [2.4.2] - 2019-01-15
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "0.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -197,7 +197,7 @@ class MiniCartContent extends Component {
       `${minicart.content} overflow-x-hidden pa1`,
       {
         [`${minicart.contentSmall} bg-base`]: !large,
-        'overflow-y-auto': large,
+        [`${minicart.contentLarge} overflow-y-auto`]: large,
         'overflow-y-scroll': items.length > MIN_ITEMS_TO_SCROLL && !large,
         'overflow-y-hidden': items.length <= MIN_ITEMS_TO_SCROLL && !large,
       }

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -203,6 +203,20 @@ class MiniCartContent extends Component {
       }
     )
 
+    const priceAndDiscountClasses = classNames(
+      `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
+      {
+        [`pv3`]: large
+      }
+    )
+
+    const checkoutButtonClasses = classNames(
+      ``,
+      {
+        [`bb bw4 bw2-m b--transparent`]: large
+      }
+    )
+
     const discount = this.calculateDiscount(items, orderForm.value)
     return (
       <Fragment>
@@ -239,9 +253,9 @@ class MiniCartContent extends Component {
           ))}
         </div>
 
-        <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt5 pb5 flex flex-column items-end`}>
+        <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pv5 flex flex-column items-end`}>
           {showDiscount && discount > 0 && (
-            <div className={`${minicart.contentDiscount} w-100 flex justify-end items-center pb3`}>
+            <div className={priceAndDiscountClasses}>
               <span className="ttl c-action-primary">{labelDiscount}</span>
               <ProductPrice
                 sellingPriceClass='c-action-primary ph2 dib'
@@ -266,13 +280,15 @@ class MiniCartContent extends Component {
               )
             }
           </div>
-          <Button
-            variation="primary"
-            size="small"
-            onClick={this.handleClickButton}
-          >
-            {label}
-          </Button>
+          <div className={checkoutButtonClasses}>
+            <Button
+              variation="primary"
+              size="small"
+              onClick={this.handleClickButton}
+              >
+              {label}
+            </Button>
+          </div>
         </div>
       </Fragment>
     )

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -239,12 +239,12 @@ class MiniCartContent extends Component {
           ))}
         </div>
 
-        <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end`}>
+        <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt5 pb5 flex flex-column items-end`}>
           {showDiscount && discount > 0 && (
-            <div className={`${minicart.contentDiscount} w-100 flex justify-end items-center`}>
-              <span className="ttl c-action-primary pb5">{labelDiscount}</span>
+            <div className={`${minicart.contentDiscount} w-100 flex justify-end items-center pb3`}>
+              <span className="ttl c-action-primary">{labelDiscount}</span>
               <ProductPrice
-                sellingPriceClass='c-action-primary ph2 dib pb5'
+                sellingPriceClass='c-action-primary ph2 dib'
                 sellingPrice={discount}
                 listPrice={discount}
                 showLabels={false}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -242,9 +242,9 @@ class MiniCartContent extends Component {
         <div className={`${minicart.contentFooter} w-100 bg-base pa4 bt b--muted-3 pt4 flex flex-column items-end`}>
           {showDiscount && discount > 0 && (
             <div className={`${minicart.contentDiscount} w-100 flex justify-end items-center`}>
-              <span className="ttl c-action-primary">{labelDiscount}</span>
+              <span className="ttl c-action-primary pb5">{labelDiscount}</span>
               <ProductPrice
-                sellingPriceClass='c-action-primary ph2 dib'
+                sellingPriceClass='c-action-primary ph2 dib pb5'
                 sellingPrice={discount}
                 listPrice={discount}
                 showLabels={false}

--- a/react/minicart.css
+++ b/react/minicart.css
@@ -21,10 +21,6 @@
   max-height: stretch;
 }
 
-.contentPrice {
-  margin-top: .5rem;
-}
-
 .badge {
   top: -0.7rem;
   right: -0.8rem;

--- a/react/minicart.css
+++ b/react/minicart.css
@@ -17,6 +17,14 @@
   max-height: 383px;
 }
 
+.contentLarge {
+  max-height: stretch;
+}
+
+.contentPrice {
+  margin-top: .5rem;
+}
+
 .badge {
   top: -0.7rem;
   right: -0.8rem;


### PR DESCRIPTION
#### What is the purpose of this pull request?
When 5 or more products are added to the minicart, the products push down the prices overlapping the checkout button. This pr aims to solve this overlapping by changing the max-height of the minicart content.

#### What problem is this solving?
The overlapping of the total price in the minicart in the mobile view.

#### How should this be manually tested?
Using chrome (mobile view) for any resolution you must add 5 or more products into the minicart and then open it. You will see the overlapping in the total price and the saved money.

This is the [Fixed Version](https://fixpriceoverlapping--storecomponents.myvtex.com/).

#### Screenshots or example usage
![bug-overlapping](https://user-images.githubusercontent.com/9946330/51056420-8a058600-15c1-11e9-865e-742167a84721.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
