### PR TITLE
Feature/shipping cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.0] - 2019-01-25
 ### Added
 Add possibility of showing shipping cost above footer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+Add possibility of showing shipping cost above footer
+
+### Changed
+Rename `large` prop to `isSizeLarge` for better description
 
 ## [2.8.0] - 2019-01-22
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,6 +6,7 @@
   "editor.minicart.labelMiniCartEmpty.title": "editor.minicart.labelMiniCartEmpty.title",
   "editor.minicart.labelButtonFinishShopping.title": "editor.minicart.labelButtonFinishShopping.title",
   "editor.minicart.enableQuantitySelector.title": "editor.minicart.enableQuantitySelector.title",
+  "editor.minicart.showShippingCost.title": "editor.minicart.showShippingCost.title",
   "editor.minicart.maxQuantity.title": "editor.minicart.maxQuantity.title",
   "editor.minicart.type.title": "editor.minicart.type.title",
   "editor.minicart.showSku.title": "editor.minicart.showSku.title",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -15,5 +15,6 @@
     "minicart-empty": "Your cart is empty!",
     "sidebar-title": "My mini cart",
     "minicart-content-footer-discount": "Save",
-    "minicart.error-removal": "Item removal failed, please try again"
+    "minicart.error-removal": "Item removal failed, please try again",
+    "minicart.shipping-cost": "Total shipping cost"
 }

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -6,6 +6,7 @@
     "editor.minicart.labelMiniCartEmpty.title": "Text to appear when the mini cart is empty",
     "editor.minicart.labelButtonFinishShopping.title": "Text to appear in the finish shopping button",
     "editor.minicart.enableQuantitySelector.title": "Enable quantity selector",
+    "editor.minicart.showShippingCost.title": "Show the shipping cost above footer",
     "editor.minicart.maxQuantity.title": "Max quantity by item",
     "editor.minicart.type.title": "Mini Cart Type",
     "editor.minicart.type.popup": "Pop Up",

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -15,5 +15,6 @@
     "minicart-empty": "Su cesta está vacía!",
     "sidebar-title": "Mi cesta de compras",
     "minicart-content-footer-discount": "Guarde",
-    "minicart.error-removal": "Falló la eliminación del artículo, por favor intente de nuevo"
+    "minicart.error-removal": "Falló la eliminación del artículo, por favor intente de nuevo",
+    "minicart.shipping-cost": "Costo total del envío"
 }

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -6,6 +6,7 @@
     "editor.minicart.labelMiniCartEmpty.title": "Texto que aparecerá cuando el carrito esté vacío",
     "editor.minicart.labelButtonFinishShopping.title": "Texto para que aparezca en el botón de finalizar compra",
     "editor.minicart.enableQuantitySelector.title": "Habilitar el selector de cantidad",
+    "editor.minicart.showShippingCost.title": "Mostrar el costo total del envío",
     "editor.minicart.maxQuantity.title": "Cantidad máxima por producto",
     "editor.minicart.type.title": "Tipo de Cesta de Compras",
     "editor.minicart.showSku.title": "Muestre el sku",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -15,5 +15,6 @@
     "minicart-empty": "Seu carrinho está vazio!",
     "sidebar-title": "Meu carrinho",
     "minicart-content-footer-discount": "Economize",
-    "minicart.error-removal": "A remoção do item falhou, por favor tente novamente"
+    "minicart.error-removal": "A remoção do item falhou, por favor tente novamente",
+    "minicart.shipping-cost": "Custo de entrega"
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -6,6 +6,7 @@
     "editor.minicart.labelMiniCartEmpty.title": "Texto que irá aparecer quando o carrinho estiver vazio",
     "editor.minicart.labelButtonFinishShopping.title": "Texto que irá aparecer no botão de finalizar compra",
     "editor.minicart.enableQuantitySelector.title": "Habilitar o seletor de quantidade",
+    "editor.minicart.showShippingCost.title": "Mostrar o custo de entrega",
     "editor.minicart.maxQuantity.title": "Quantidade máxima por item",
     "editor.minicart.type.title": "Tipo de Carrinho de Compras",
     "editor.minicart.type.popup": "Pop Up",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -22,7 +22,7 @@ const TOAST_TIMEOUT = 4000
 class MiniCartContent extends Component {
   static propTypes = {
     /* Set the mini cart content size */
-    large: PropTypes.bool,
+    isSizeLarge: PropTypes.bool,
     /* Internationalization */
     intl: intlShape.isRequired,
     /** Define a function that is executed when the item is clicked */
@@ -204,7 +204,7 @@ class MiniCartContent extends Component {
     showDiscount,
     actionOnClick,
     isUpdating,
-    large,
+    isSizeLarge,
     showShippingCost
   ) => {
     const items = groupItemsWithParents(orderForm)
@@ -213,10 +213,10 @@ class MiniCartContent extends Component {
     const classes = classNames(
       `${minicart.content} overflow-x-hidden pa1 overflow-y-auto`,
       {
-        [`${minicart.contentSmall} bg-base`]: !large,
-        [`${minicart.contentLarge}`]: large,
-        'overflow-y-scroll': items.length > MIN_ITEMS_TO_SCROLL && !large,
-        'overflow-y-hidden': items.length <= MIN_ITEMS_TO_SCROLL && !large,
+        [`${minicart.contentSmall} bg-base`]: !isSizeLarge,
+        [`${minicart.contentLarge}`]: isSizeLarge,
+        'overflow-y-scroll': items.length > MIN_ITEMS_TO_SCROLL && !isSizeLarge,
+        'overflow-y-hidden': items.length <= MIN_ITEMS_TO_SCROLL && !isSizeLarge,
       }
     )
 
@@ -259,7 +259,7 @@ class MiniCartContent extends Component {
           isUpdating={this.isUpdating}
           totalValue={orderForm.value}
           buttonLabel={label}
-          large={large}
+          isSizeLarge={isSizeLarge}
           labelDiscount={labelDiscount}
           showDiscount={showDiscount}
           showShippingCost={showShippingCost}
@@ -282,7 +282,7 @@ class MiniCartContent extends Component {
       intl,
       showDiscount,
       actionOnClick,
-      large,
+      isSizeLarge,
       showShippingCost,
     } = this.props
     const { isUpdating } = this.state
@@ -310,7 +310,7 @@ class MiniCartContent extends Component {
       showDiscount,
       actionOnClick,
       isUpdating,
-      large,
+      isSizeLarge,
       showShippingCost
     )
   }

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -36,6 +36,7 @@ class MiniCartContent extends Component {
     enableQuantitySelector: MiniCartPropTypes.enableQuantitySelector,
     maxQuantity: MiniCartPropTypes.maxQuantity,
     showDiscount: MiniCartPropTypes.showDiscount,
+    showShippingCost: MiniCartPropTypes.showShippingCost,
   }
 
   state = { isUpdating: [] }
@@ -203,7 +204,8 @@ class MiniCartContent extends Component {
     showDiscount,
     actionOnClick,
     isUpdating,
-    large
+    large,
+    showShippingCost
   ) => {
     const items = groupItemsWithParents(orderForm)
     const MIN_ITEMS_TO_SCROLL = 2
@@ -260,6 +262,7 @@ class MiniCartContent extends Component {
           large={large}
           labelDiscount={labelDiscount}
           showDiscount={showDiscount}
+          showShippingCost={showShippingCost}
         />
       </Fragment>
     )
@@ -280,6 +283,7 @@ class MiniCartContent extends Component {
       showDiscount,
       actionOnClick,
       large,
+      showShippingCost,
     } = this.props
     const { isUpdating } = this.state
 
@@ -306,7 +310,8 @@ class MiniCartContent extends Component {
       showDiscount,
       actionOnClick,
       isUpdating,
-      large
+      large,
+      showShippingCost
     )
   }
 }

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -1,0 +1,107 @@
+import React, { PureComponent, Fragment } from 'react'
+import classNames from 'classnames'
+import ProductPrice from 'vtex.store-components/ProductPrice'
+import { Button, Spinner } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
+import PropTypes from 'prop-types'
+
+import minicart from '../minicart.css'
+
+class MiniCartFooter extends PureComponent {
+  static propTypes = {
+    shippingCost: PropTypes.number,
+    large: PropTypes.bool,
+    isUpdating: PropTypes.bool,
+    totalValue: PropTypes.number.isRequired,
+    buttonLabel: PropTypes.string.isRequired,
+    showDiscount: PropTypes.bool,
+    discount: PropTypes.number,
+    labelDiscount: PropTypes.string,
+  }
+
+  handleClickButton = () => location.assign('/checkout/#/cart')
+
+  render() {
+    const { shippingCost, large, isUpdating, totalValue, buttonLabel, showDiscount, discount, labelDiscount } = this.props
+
+    const priceAndDiscountClasses = classNames(
+      `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
+      {
+        'pv3': large,
+      }
+    )
+
+    const checkoutButtonClasses = classNames(
+      '',
+      {
+        'bb bw4 bw2-m b--transparent': large,
+      }
+    )
+
+    const showShippingCost = shippingCost > 0
+
+    const footerClasses = classNames(
+      `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
+      {
+        'bt b--muted-3': showShippingCost || large,
+      }
+    )
+
+    return (
+      <Fragment>
+        {showShippingCost && (
+          <div className="flex w-100 items-center justify-between ph4 pv4">
+            <div className="t-body c-muted-1">
+              <FormattedMessage id="minicart.shipping-cost" />
+            </div>
+            <ProductPrice
+              sellingPriceClass="t-heading-5-ns b c-on-base ph2 dib"
+              sellingPrice={shippingCost}
+              showLabels={false}
+              showListPrice={false}
+            />
+          </div>
+        )}
+        <div className={footerClasses}>
+          {showDiscount && discount > 0 && (
+            <div className={priceAndDiscountClasses}>
+              <span className="ttl c-action-primary">{labelDiscount}</span>
+              <ProductPrice
+                sellingPriceClass="c-action-primary t-body ph2 dib"
+                sellingPrice={discount}
+                listPrice={discount}
+                showLabels={false}
+                showListPrice={false}
+              />
+            </div>
+          )}
+          <div className={`${minicart.contentPrice} mb3`}>
+            {isUpdating
+              ? (<Spinner size={18} />)
+              : (
+                <ProductPrice
+                  sellingPriceClass="t-heading-5-ns c-on-base b ph2 dib"
+                  sellingPrice={totalValue}
+                  listPrice={totalValue}
+                  showLabels={false}
+                  showListPrice={false}
+                />
+              )
+            }
+          </div>
+          <div className={checkoutButtonClasses}>
+            <Button
+              variation="primary"
+              size="small"
+              onClick={this.handleClickButton}
+            >
+              {buttonLabel}
+            </Button>
+          </div>
+        </div>
+      </Fragment>
+    )
+  }
+}
+
+export default MiniCartFooter

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react'
+import React, { Fragment, memo } from 'react'
 import classNames from 'classnames'
 import ProductPrice from 'vtex.store-components/ProductPrice'
 import { Button, Spinner } from 'vtex.styleguide'
@@ -8,111 +8,108 @@ import PropTypes from 'prop-types'
 import { MiniCartPropTypes } from '../propTypes'
 import minicart from '../minicart.css'
 
-class MiniCartFooter extends PureComponent {
-  static propTypes = {
-    shippingCost: PropTypes.number,
-    isSizeLarge: PropTypes.bool,
-    isUpdating: PropTypes.bool,
-    totalValue: PropTypes.number.isRequired,
-    buttonLabel: PropTypes.string.isRequired,
-    showDiscount: MiniCartPropTypes.showDiscount,
-    discount: PropTypes.number,
-    labelDiscount: PropTypes.string,
-    showShippingCost: MiniCartPropTypes.showShippingCost,
-  }
+const handleClickButton = () => location.assign('/checkout/#/cart')
 
-  handleClickButton = () => location.assign('/checkout/#/cart')
+const MiniCartFooter =({
+  shippingCost, 
+  isSizeLarge, 
+  isUpdating, 
+  totalValue, 
+  buttonLabel, 
+  showDiscount, 
+  discount, 
+  labelDiscount,
+  showShippingCost
+}) => {
+  const priceAndDiscountClasses = classNames(
+    `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
+    {
+      'pv3': isSizeLarge,
+    }
+  )
 
-  render() {
-    const { 
-      shippingCost, 
-      isSizeLarge, 
-      isUpdating, 
-      totalValue, 
-      buttonLabel, 
-      showDiscount, 
-      discount, 
-      labelDiscount,
-      showShippingCost
-     } = this.props
+  const checkoutButtonClasses = classNames(
+    {
+      'bb bw4 bw2-m b--transparent': isSizeLarge,
+    }
+  )
 
-    const priceAndDiscountClasses = classNames(
-      `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
-      {
-        'pv3': isSizeLarge,
-      }
-    )
+  const shouldShowShippingCost = showShippingCost && shippingCost > 0
 
-    const checkoutButtonClasses = classNames(
-      {
-        'bb bw4 bw2-m b--transparent': isSizeLarge,
-      }
-    )
+  const footerClasses = classNames(
+    `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
+    {
+      'bt b--muted-3': shouldShowShippingCost || isSizeLarge,
+    }
+  )
 
-    const shouldShowShippingCost = showShippingCost && shippingCost > 0
-
-    const footerClasses = classNames(
-      `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
-      {
-        'bt b--muted-3': shouldShowShippingCost || isSizeLarge,
-      }
-    )
-
-    return (
-      <Fragment>
-        {shouldShowShippingCost && (
-          <div className="flex w-100 items-center justify-between ph4 pv4">
-            <div className="t-body c-muted-1">
-              <FormattedMessage id="minicart.shipping-cost" />
-            </div>
+  return (
+    <Fragment>
+      {shouldShowShippingCost && (
+        <div className="flex w-100 items-center justify-between ph4 pv4">
+          <div className="t-body c-muted-1">
+            <FormattedMessage id="minicart.shipping-cost" />
+          </div>
+          <ProductPrice
+            sellingPriceClass="t-heading-5-ns b c-on-base ph2 dib"
+            sellingPrice={shippingCost}
+            showLabels={false}
+            showListPrice={false}
+          />
+        </div>
+      )}
+      <div className={footerClasses}>
+        {showDiscount && discount > 0 && (
+          <div className={priceAndDiscountClasses}>
+            <span className="ttl c-action-primary">{labelDiscount}</span>
             <ProductPrice
-              sellingPriceClass="t-heading-5-ns b c-on-base ph2 dib"
-              sellingPrice={shippingCost}
+              sellingPriceClass="c-action-primary t-body ph2 dib"
+              sellingPrice={discount}
+              listPrice={discount}
               showLabels={false}
               showListPrice={false}
             />
           </div>
         )}
-        <div className={footerClasses}>
-          {showDiscount && discount > 0 && (
-            <div className={priceAndDiscountClasses}>
-              <span className="ttl c-action-primary">{labelDiscount}</span>
+        <div className={`${minicart.contentPrice} mb3`}>
+          {isUpdating
+            ? <Spinner size={18} />
+            : (
               <ProductPrice
-                sellingPriceClass="c-action-primary t-body ph2 dib"
-                sellingPrice={discount}
-                listPrice={discount}
+                sellingPriceClass="t-heading-5-ns c-on-base b ph2 dib"
+                sellingPrice={totalValue}
+                listPrice={totalValue}
                 showLabels={false}
                 showListPrice={false}
               />
-            </div>
-          )}
-          <div className={`${minicart.contentPrice} mb3`}>
-            {isUpdating
-              ? (<Spinner size={18} />)
-              : (
-                <ProductPrice
-                  sellingPriceClass="t-heading-5-ns c-on-base b ph2 dib"
-                  sellingPrice={totalValue}
-                  listPrice={totalValue}
-                  showLabels={false}
-                  showListPrice={false}
-                />
-              )
-            }
-          </div>
-          <div className={checkoutButtonClasses}>
-            <Button
-              variation="primary"
-              size="small"
-              onClick={this.handleClickButton}
-            >
-              {buttonLabel}
-            </Button>
-          </div>
+            )
+          }
         </div>
-      </Fragment>
-    )
-  }
+        <div className={checkoutButtonClasses}>
+          <Button
+            variation="primary"
+            size="small"
+            onClick={handleClickButton}
+          >
+            {buttonLabel}
+          </Button>
+        </div>
+      </div>
+    </Fragment>
+  )
+
 }
 
-export default MiniCartFooter
+MiniCartFooter.propTypes = {
+  shippingCost: PropTypes.number,
+  isSizeLarge: PropTypes.bool,
+  isUpdating: PropTypes.bool,
+  totalValue: PropTypes.number.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  showDiscount: MiniCartPropTypes.showDiscount,
+  discount: PropTypes.number,
+  labelDiscount: PropTypes.string,
+  showShippingCost: MiniCartPropTypes.showShippingCost,
+}
+
+export default memo(MiniCartFooter)

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -11,7 +11,7 @@ import minicart from '../minicart.css'
 class MiniCartFooter extends PureComponent {
   static propTypes = {
     shippingCost: PropTypes.number,
-    large: PropTypes.bool,
+    isSizeLarge: PropTypes.bool,
     isUpdating: PropTypes.bool,
     totalValue: PropTypes.number.isRequired,
     buttonLabel: PropTypes.string.isRequired,
@@ -26,7 +26,7 @@ class MiniCartFooter extends PureComponent {
   render() {
     const { 
       shippingCost, 
-      large, 
+      isSizeLarge, 
       isUpdating, 
       totalValue, 
       buttonLabel, 
@@ -39,14 +39,13 @@ class MiniCartFooter extends PureComponent {
     const priceAndDiscountClasses = classNames(
       `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
       {
-        'pv3': large,
+        'pv3': isSizeLarge,
       }
     )
 
     const checkoutButtonClasses = classNames(
-      '',
       {
-        'bb bw4 bw2-m b--transparent': large,
+        'bb bw4 bw2-m b--transparent': isSizeLarge,
       }
     )
 
@@ -55,7 +54,7 @@ class MiniCartFooter extends PureComponent {
     const footerClasses = classNames(
       `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
       {
-        'bt b--muted-3': shouldShowShippingCost || large,
+        'bt b--muted-3': shouldShowShippingCost || isSizeLarge,
       }
     )
 

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -5,6 +5,7 @@ import { Button, Spinner } from 'vtex.styleguide'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 
+import { MiniCartPropTypes } from '../propTypes'
 import minicart from '../minicart.css'
 
 class MiniCartFooter extends PureComponent {
@@ -14,15 +15,26 @@ class MiniCartFooter extends PureComponent {
     isUpdating: PropTypes.bool,
     totalValue: PropTypes.number.isRequired,
     buttonLabel: PropTypes.string.isRequired,
-    showDiscount: PropTypes.bool,
+    showDiscount: MiniCartPropTypes.showDiscount,
     discount: PropTypes.number,
     labelDiscount: PropTypes.string,
+    showShippingCost: MiniCartPropTypes.showShippingCost,
   }
 
   handleClickButton = () => location.assign('/checkout/#/cart')
 
   render() {
-    const { shippingCost, large, isUpdating, totalValue, buttonLabel, showDiscount, discount, labelDiscount } = this.props
+    const { 
+      shippingCost, 
+      large, 
+      isUpdating, 
+      totalValue, 
+      buttonLabel, 
+      showDiscount, 
+      discount, 
+      labelDiscount,
+      showShippingCost
+     } = this.props
 
     const priceAndDiscountClasses = classNames(
       `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,
@@ -38,18 +50,18 @@ class MiniCartFooter extends PureComponent {
       }
     )
 
-    const showShippingCost = shippingCost > 0
+    const shouldShowShippingCost = showShippingCost && shippingCost > 0
 
     const footerClasses = classNames(
       `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
       {
-        'bt b--muted-3': showShippingCost || large,
+        'bt b--muted-3': shouldShowShippingCost || large,
       }
     )
 
     return (
       <Fragment>
-        {showShippingCost && (
+        {shouldShowShippingCost && (
           <div className="flex w-100 items-center justify-between ph4 pv4">
             <div className="t-body c-muted-1">
               <FormattedMessage id="minicart.shipping-cost" />

--- a/react/index.js
+++ b/react/index.js
@@ -90,18 +90,16 @@ export class MiniCart extends Component {
       showShippingCost,
     } = this.props
 
-    console.log('teste showShippingCost: ', showShippingCost)
-
     const quantity = this.itemsQuantity
 
-    const large =
+    const isSizeLarge =
       (type && type === 'sidebar') ||
       isMobile ||
       (window && window.innerWidth <= 480)
 
     const miniCartContent = (
       <MiniCartContent
-        large={large}
+        isSizeLarge={isSizeLarge}
         data={orderFormContext}
         showRemoveButton={showRemoveButton}
         showDiscount={showDiscount}
@@ -148,7 +146,7 @@ export class MiniCart extends Component {
           </div>
         </Button>
         {!hideContent &&
-          (large ? (
+          (isSizeLarge ? (
             <Sidebar
               onOutsideClick={this.handleUpdateContentVisibility}
               isOpen={openContent}

--- a/react/index.js
+++ b/react/index.js
@@ -87,7 +87,10 @@ export class MiniCart extends Component {
       orderFormContext,
       type,
       hideContent,
+      showShippingCost,
     } = this.props
+
+    console.log('teste showShippingCost: ', showShippingCost)
 
     const quantity = this.itemsQuantity
 
@@ -110,6 +113,7 @@ export class MiniCart extends Component {
         onClickProduct={this.onClickProduct}
         handleUpdateContentVisibility={this.handleUpdateContentVisibility}
         actionOnClick={this.handleUpdateContentVisibility}
+        showShippingCost={showShippingCost}
       />
     )
 

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -30,4 +30,6 @@ export const MiniCartPropTypes = {
   maxQuantity: PropTypes.number,
   /* Products in the cart */
   orderFormContext: contextPropTypes,
+  /* Set the shipping fee visibility */
+  showShippingCost: PropTypes.bool,
 }


### PR DESCRIPTION
também quebrei o Footer com o shipping cost para um component separado, para deixar mais organizado,

Exemplo:
<img width="386" alt="screen shot 2019-01-24 at 7 15 38 pm" src="https://user-images.githubusercontent.com/4925068/51748304-23896900-2093-11e9-92fb-63b3859552b5.png">

<img width="315" alt="screen shot 2019-01-24 at 7 15 47 pm" src="https://user-images.githubusercontent.com/4925068/51748315-2dab6780-2093-11e9-9e6e-5e7763f98a3f.png">

Também adicionado uma nova prop para ser passado no `blocks.json`, chamado `showShippingCost`. Por default, vem indefinida logo não quebra ou altera o visual de lojas que já funcionam normalmente sem essa PR.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
