### PR TITLE
use choice type as a ENUM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Send to product-summary the "choice type" of each assembly option (SINGLE, TOGGLE or MULTIPLE)
 
 ## [2.9.0] - 2019-01-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove inherit component from `blocks.json`
+
 ### Changed
 - Send to product-summary the "choice type" of each assembly option (SINGLE, TOGGLE or MULTIPLE)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.1] - 2019-01-29
 ### Fixed
 - Remove inherit component from `blocks.json`
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -7,7 +7,7 @@ import { ExtensionPoint } from 'vtex.render-runtime'
 import { Button, Spinner, IconDelete } from 'vtex.styleguide'
 import { MiniCartPropTypes } from '../propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
-import { groupItemsWithParents, isSingleChoiceOption } from '../utils/itemsHelper'
+import { groupItemsWithParents, getOptionChoiceType } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
 import MiniCartFooter from './MiniCartFooter';
@@ -161,7 +161,7 @@ class MiniCartContent extends Component {
 
   createProductShapeFromOption = (option) => ({
     ...this.createProductShapeFromItem(option),
-    isSingleChoice: isSingleChoiceOption(option, this.props.data.orderForm),
+    choiceType: getOptionChoiceType(option, this.props.data.orderForm),
     optionType: option.parentAssemblyBinding && last(split('_', option.parentAssemblyBinding)),
   })
 

--- a/react/utils/__tests__/itemsHelper.test.js
+++ b/react/utils/__tests__/itemsHelper.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { isParentItem, isSingleChoiceOption, groupItemsWithParents } from '../itemsHelper'
+import { isParentItem, groupItemsWithParents, getOptionChoiceType, CHOICE_TYPES } from '../itemsHelper'
 import orderForm from '../__mocks__/orderForm.json'
 
 it('should return only items that dont have parent', () => {
@@ -24,12 +24,14 @@ it('should group items and its attachments', () => {
 it('should return crust item as single choice', () => {
   const items = orderForm.items
   const classicCrust = items.find(({ name }) => name === 'Classic Crust')
-  const isCrustRequired = isSingleChoiceOption(classicCrust, orderForm)
-  expect(isCrustRequired).toBe(true)
-  
+  const isCrustRequired = getOptionChoiceType(classicCrust, orderForm)
+  expect(isCrustRequired).toBe(CHOICE_TYPES.SINGLE)
+})
+
+it('should return pepperoni item as toggle choice', () => {
+  const items = orderForm.items
   const pepperoni = items.find(({ name }) => name === 'Pepperoni')
-  const isPepperoniRequired = isSingleChoiceOption(pepperoni, orderForm)
-  // should be false
-  expect(isPepperoniRequired).toBe(false)
+  const isPepperoniToggle = getOptionChoiceType(pepperoni, orderForm)
+  expect(isPepperoniToggle).toBe(CHOICE_TYPES.TOGGLE)
 })
 

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -2,7 +2,6 @@
   "minicart": {
     "blocks": [
       "product-summary"
-    ],
-    "inheritComponent": true
+    ]
   }
 }


### PR DESCRIPTION
<img width="397" alt="screen shot 2019-01-28 at 8 15 28 pm" src="https://user-images.githubusercontent.com/4925068/51870153-e72b6680-2339-11e9-8d6d-0cbff4e7dc10.png">

Mandar para o product-summary como um ENUM o 'choiceType', indicando se esse attachment é um "SINGLE" (como uma borda, única e obrigatória), "MULTIPLE" (como o champignon/pimentão que pode colocar 0 ou até 3) ou "TOGGLE" (caso dos ingredientes básicos que vem 0 ou 1, como pepperoni na pizza de pepperoni).

ws para teste: https://testemini--delivery.myvtex.com/

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
