### PR TITLE
Fix minicart flick when the scroll is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.11.5] - 2019-02-15
 ### Fixed
 - Minicart flick when scroll is being displayed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Minicart flick when scroll is being displayed.
 
 ## [2.11.4] - 2019-02-15
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -13,7 +13,7 @@ import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
 import { groupItemsWithParents, getOptionChoiceType, getOptionComposition } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
-import MiniCartFooter from './MiniCartFooter';
+import MiniCartFooter from './MiniCartFooter'
 
 /**
  * Minicart content component

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -215,7 +215,7 @@ class MiniCartContent extends Component {
     const MIN_ITEMS_TO_SCROLL = 2
 
     const classes = classNames(
-      `${minicart.content} overflow-x-hidden pa1 overflow-y-auto`,
+      `${minicart.content} overflow-x-hidden pa1`,
       {
         [`${minicart.contentSmall} bg-base`]: !isSizeLarge,
         [`${minicart.contentLarge}`]: isSizeLarge,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix minicart flick on item quantity update and when there are 3 itens

#### What problem is this solving?
When there are 3 itens on the minicart with the scroll being displayed, if the quantity changes the minicart content "flicks".

#### How should this be manually tested?
[Access workspace](https://minicartflick--storecomponents.myvtex.com/)

Try to add 3 itens on minicart and update the quantity of any.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
