### PR TITLE
protect against itemmetadata null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Protect against `itemMetadata` null
 
 ## [2.10.1] - 2019-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.2] - 2019-02-05
 ### Fixed
 - Protect against `itemMetadata` null
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/utils/itemsHelper.js
+++ b/react/utils/itemsHelper.js
@@ -29,7 +29,7 @@ export const groupItemsWithParents = (orderForm) => {
 
 const findParentOption = (item, orderForm) => {
   const { parentItemIndex, parentAssemblyBinding } = item
-  if (isParentItem(item)) { return null }
+  if (!orderForm.itemMetadata || isParentItem(item)) { return null }
   const parentId = orderForm.items[parentItemIndex].id
 
   const parentMetadata = find(propEq('id', parentId))(orderForm.itemMetadata.items)


### PR DESCRIPTION
In some cases, checkout, by mistake, is delivering field `itemMetadata: null` even though we have items with assembly options. Protect against this case while it is not fixed.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
