### PR TITLE
Fix/compostion item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Pass composition item to product summary
+
+### Fixed
+- Small margin adjustments for shipping cost view
 
 ## [2.10.3] - 2019-02-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.4] - 2019-02-08
 ### Changed
 - Pass composition item to product summary
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -10,7 +10,7 @@ import { IconDelete } from 'vtex.dreamstore-icons'
 
 import { MiniCartPropTypes } from '../propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
-import { groupItemsWithParents, getOptionChoiceType } from '../utils/itemsHelper'
+import { groupItemsWithParents, getOptionChoiceType, getCompositionForOption } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
 import MiniCartFooter from './MiniCartFooter';
@@ -164,6 +164,7 @@ class MiniCartContent extends Component {
 
   createProductShapeFromOption = (option) => ({
     ...this.createProductShapeFromItem(option),
+    compositionItem: getCompositionForOption(option, this.props.data.orderForm),
     choiceType: getOptionChoiceType(option, this.props.data.orderForm),
     optionType: option.parentAssemblyBinding && last(split('_', option.parentAssemblyBinding)),
   })

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -10,7 +10,7 @@ import { IconDelete } from 'vtex.dreamstore-icons'
 
 import { MiniCartPropTypes } from '../propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
-import { groupItemsWithParents, getOptionChoiceType, getCompositionForOption } from '../utils/itemsHelper'
+import { groupItemsWithParents, getOptionChoiceType, getOptionComposition } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
 import MiniCartFooter from './MiniCartFooter';
@@ -164,7 +164,7 @@ class MiniCartContent extends Component {
 
   createProductShapeFromOption = (option) => ({
     ...this.createProductShapeFromItem(option),
-    compositionItem: getCompositionForOption(option, this.props.data.orderForm),
+    compositionItem: getOptionComposition(option, this.props.data.orderForm),
     choiceType: getOptionChoiceType(option, this.props.data.orderForm),
     optionType: option.parentAssemblyBinding && last(split('_', option.parentAssemblyBinding)),
   })

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -46,7 +46,7 @@ const MiniCartFooter =({
   return (
     <Fragment>
       {shouldShowShippingCost && (
-        <div className="flex w-100 items-center justify-between ph4 pv4">
+        <div className="flex items-center justify-between ma5">
           <div className="t-body c-muted-1">
             <FormattedMessage id="minicart.shipping-cost" />
           </div>

--- a/react/utils/itemsHelper.js
+++ b/react/utils/itemsHelper.js
@@ -53,3 +53,9 @@ export const getOptionChoiceType = (item, orderForm) => {
 
   return CHOICE_TYPES.MULTIPLE
 }
+
+export const getCompositionForOption = (option, orderForm) => {
+  const parentOption = findParentOption(option, orderForm)
+  if (!parentOption) { return {} }
+  return find(propEq('id', option.id))(parentOption.composition.items) || {}
+}

--- a/react/utils/itemsHelper.js
+++ b/react/utils/itemsHelper.js
@@ -54,7 +54,7 @@ export const getOptionChoiceType = (item, orderForm) => {
   return CHOICE_TYPES.MULTIPLE
 }
 
-export const getCompositionForOption = (option, orderForm) => {
+export const getOptionComposition = (option, orderForm) => {
   const parentOption = findParentOption(option, orderForm)
   if (!parentOption) { return {} }
   return find(propEq('id', option.id))(parentOption.composition.items) || {}


### PR DESCRIPTION
https://initial--phmex.myvtex.com/

pass composition item so product-summary can correctly use rule to choose what attachments to display

desktop
<img width="371" alt="screen shot 2019-02-07 at 3 58 25 pm" src="https://user-images.githubusercontent.com/4925068/52438846-5a369900-2b01-11e9-9abf-7285b4848726.png">

mobile
<img width="283" alt="screen shot 2019-02-07 at 3 58 30 pm" src="https://user-images.githubusercontent.com/4925068/52438847-5a369900-2b01-11e9-9f8f-2ed370ed9385.png">

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
