### PR TITLE
Put orderForm into the LinkState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the `orderForm` to the LinkState.
+
+### Fixed
+- Fix items `upToDate` logic.
+- Remove `orderForm` refetch.
 
 ## [2.11.3] - 2019-02-14
 

--- a/react/LinkState.js
+++ b/react/LinkState.js
@@ -3,8 +3,8 @@ const gql = require('graphql-tag')
 const minicartItemsQuery = gql`
   query {
     minicart @client {
-      upToDate
       items {
+        upToDate
         id
         name
         imageUrl
@@ -50,7 +50,6 @@ const resolvers = {
           minicart: {
             __typename: 'Minicart',
             items: newItems.concat(prevItems).map(mapToMinicartItem),
-            upToDate: false,
           },
         },
       })
@@ -71,7 +70,7 @@ const resolvers = {
 
       cache.writeData({
         data: {
-          minicart: { __typename: 'Minicart', items, upToDate: false },
+          minicart: { __typename: 'Minicart', items },
         },
       })
       return items
@@ -92,10 +91,15 @@ const resolvers = {
 }
 
 function updateLinkStateItems(newItems, cache) {
-  const items = newItems.map(mapToMinicartItem)
+  const items = newItems.map(item =>
+    mapToMinicartItem({
+      upToDate: true,
+      ...item,
+    })
+  )
   cache.writeData({
     data: {
-      minicart: { __typename: 'Minicart', items, upToDate: true },
+      minicart: { __typename: 'Minicart', items },
     },
   })
   return items
@@ -147,19 +151,19 @@ const mapToOrderFormStorePreferences = storePreferencesData => ({
 })
 
 const mapToMinicartItem = item => ({
-  __typename: 'MinicartItem',
   seller: null,
   index: null,
   parentItemIndex: null,
   parentAssemblyBinding: null,
+  upToDate: false,
   ...item,
+  __typename: 'MinicartItem',
 })
 
 const initialState = {
   minicart: {
     __typename: 'Minicart',
     items: [],
-    upToDate: false,
     orderForm: null,
   },
 }

--- a/react/LinkState.js
+++ b/react/LinkState.js
@@ -76,15 +76,6 @@ const resolvers = {
       })
       return items
     },
-    fillCart: (_, { items: newItems }, { cache }) => {
-      const items = newItems.map(mapToMinicartItem)
-      cache.writeData({
-        data: {
-          minicart: { __typename: 'Minicart', items, upToDate: true },
-        },
-      })
-      return items
-    },
     updateOrderForm: (_, { orderForm: newOrderForm }, { cache }) => {
       const orderForm = mapToLinkStateOrderForm(newOrderForm)
       cache.writeData({

--- a/react/LinkState.js
+++ b/react/LinkState.js
@@ -49,7 +49,12 @@ const resolvers = {
         data: {
           minicart: {
             __typename: 'Minicart',
-            items: newItems.concat(prevItems).map(mapToMinicartItem),
+            items: newItems.concat(prevItems).map(item =>
+              mapToMinicartItem({
+                ...item,
+                upToDate: false,
+              })
+            ),
           },
         },
       })
@@ -64,7 +69,7 @@ const resolvers = {
       const items = prevItems
         .map(prevItem => {
           const newItem = newItems.find(({ id }) => id === prevItem.id)
-          return newItem || prevItem
+          return newItem ? { ...newItem, upToDate: false } : prevItem
         })
         .map(mapToMinicartItem)
 
@@ -155,7 +160,6 @@ const mapToMinicartItem = item => ({
   index: null,
   parentItemIndex: null,
   parentAssemblyBinding: null,
-  upToDate: false,
   ...item,
   __typename: 'MinicartItem',
 })

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -219,7 +219,6 @@ class MiniCartContent extends Component {
                     id="product-summary"
                     showBorders
                     product={this.createProductShapeFromItem(item)}
-                    name={item.name}
                     displayMode="inline"
                     showListPrice={false}
                     showBadge={false}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -44,6 +44,8 @@ class MiniCartContent extends Component {
 
     /* Update Items mutation */
     updateItems: PropTypes.func.isRequired,
+    /* Determines if the orderform is updating */
+    updatingOrderForm: PropTypes.bool,
   }
 
   state = { isUpdating: [] }
@@ -142,9 +144,13 @@ class MiniCartContent extends Component {
   get isUpdating() {
     const { isUpdating } = this.state
     const {
-      orderForm: { items },
-    } = this.props.data
+      data: {
+        orderForm: { items },
+      },
+      updatingOrderForm,
+    } = this.props
     return (
+      updatingOrderForm ||
       items.some(item => !!item.seller || item.quantity === 0) ||
       isUpdating.some(status => status)
     )
@@ -154,7 +160,7 @@ class MiniCartContent extends Component {
     <div
       className={`${
         minicart.item
-        } pa9 flex items-center justify-center relative bg-base`}
+      } pa9 flex items-center justify-center relative bg-base`}
     >
       <span className="t-body">{label}</span>
     </div>
@@ -198,14 +204,14 @@ class MiniCartContent extends Component {
                         <Spinner size={18} />
                       </div>
                     ) : (
-                        <Button
-                          icon
-                          variation="tertiary"
-                          onClick={() => this.handleItemRemoval(item.id)}
-                        >
-                          <IconDelete size={15} activeClassName="c-muted-2" />
-                        </Button>
-                      )}
+                      <Button
+                        icon
+                        variation="tertiary"
+                        onClick={() => this.handleItemRemoval(item.id)}
+                      >
+                        <IconDelete size={15} activeClassName="c-muted-2" />
+                      </Button>
+                    )}
                   </div>
                   <ExtensionPoint
                     id="product-summary"
@@ -241,7 +247,7 @@ class MiniCartContent extends Component {
     <div
       className={`${
         minicart.item
-        } pa4 flex items-center justify-center relative bg-base`}
+      } pa4 flex items-center justify-center relative bg-base`}
     >
       <Spinner />
     </div>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -15,6 +15,7 @@ import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
 import {
   groupItemsWithParents,
   getOptionChoiceType,
+  getOptionComposition,
 } from '../utils/itemsHelper'
 
 import minicart from '../minicart.css'
@@ -32,7 +33,7 @@ class MiniCartContent extends Component {
     /** Define a function that is executed when the item is clicked */
     onClickAction: PropTypes.func,
     /* Reused props */
-    data: MiniCartPropTypes.orderFormContext,
+    data: PropTypes.object,
     labelMiniCartEmpty: MiniCartPropTypes.labelMiniCartEmpty,
     labelButton: MiniCartPropTypes.labelButtonFinishShopping,
     showRemoveButton: MiniCartPropTypes.showRemoveButton,
@@ -111,6 +112,7 @@ class MiniCartContent extends Component {
 
   createProductShapeFromOption = option => ({
     ...this.createProductShapeFromItem(option),
+    compositionItem: getOptionComposition(option, this.props.data.orderForm),
     choiceType: getOptionChoiceType(option, this.props.data.orderForm),
     optionType:
       option.parentAssemblyBinding &&
@@ -126,7 +128,7 @@ class MiniCartContent extends Component {
           Price:
             item.sellingPrice * item.quantity +
             this.sumOptionsSellingPrice(item.addedOptions),
-          ListPrice: item.ListPrice,
+          ListPrice: item.listPrice,
         },
       },
       name: item.skuName,

--- a/react/index.js
+++ b/react/index.js
@@ -60,7 +60,6 @@ export class MiniCart extends Component {
 
   handleItemsUpdate = async () => {
     const clientOnlyItems = this.getClientOnlyItems()
-    console.log(clientOnlyItems)
     if (clientOnlyItems.length && !this.state.updatingOrderForm) {
       return this.handleItemsDifference(clientOnlyItems)
     }

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,4 @@
-import { isNil, path, pathOr, pick } from 'ramda'
+import { path, pathOr, pick } from 'ramda'
 import React, { Component } from 'react'
 import { Button } from 'vtex.styleguide'
 import { isMobile } from 'react-device-detect'
@@ -53,14 +53,15 @@ export class MiniCart extends Component {
     this.handleOrderFormUpdate(prevProps)
   }
 
-  handleItemsUpdate = async () => {
-    const clientItems = path(['linkState', 'minicartItems'], this.props)
+  getClientOnlyItems = () => {
+    const clientItems = pathOr([], ['linkState', 'minicartItems'], this.props)
+    return clientItems.filter(({ upToDate }) => !upToDate)
+  }
 
-    if (clientItems && !this.state.updatingOrderForm) {
-      const clientOnlyItems = clientItems.filter(({ seller }) => !isNil(seller))
-      if (clientOnlyItems.length) {
-        return this.handleItemsDifference(clientOnlyItems)
-      }
+  handleItemsUpdate = async () => {
+    const clientOnlyItems = this.getClientOnlyItems()
+    if (clientOnlyItems.length && !this.state.updatingOrderForm) {
+      return this.handleItemsDifference(clientOnlyItems)
     }
   }
 
@@ -202,6 +203,7 @@ export class MiniCart extends Component {
         onClickProduct={this.handleClickProduct}
         onClickAction={this.handleUpdateContentVisibility}
         showShippingCost={showShippingCost}
+        updatingOrderForm={this.state.updatingOrderForm}
       />
     )
 
@@ -224,7 +226,7 @@ export class MiniCart extends Component {
                 <span
                   className={`${
                     minicart.badge
-                    } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+                  } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
                 >
                   {quantity}
                 </span>
@@ -234,7 +236,7 @@ export class MiniCart extends Component {
               <span
                 className={`${minicart.label} dn-m db-l t-action--small pl${
                   quantity > 0 ? '6' : '4'
-                  } ${labelClasses}`}
+                } ${labelClasses}`}
               >
                 {iconLabel}
               </span>
@@ -252,15 +254,15 @@ export class MiniCart extends Component {
               {miniCartContent}
             </Sidebar>
           ) : (
-              openContent && (
-                <Popup
-                  onOutsideClick={this.handleUpdateContentVisibility}
-                  buttonOffsetWidth={this.iconRef.offsetWidth}
-                >
-                  {miniCartContent}
-                </Popup>
-              )
-            ))}
+            openContent && (
+              <Popup
+                onOutsideClick={this.handleUpdateContentVisibility}
+                buttonOffsetWidth={this.iconRef.offsetWidth}
+              >
+                {miniCartContent}
+              </Popup>
+            )
+          ))}
       </aside>
     )
   }

--- a/react/index.js
+++ b/react/index.js
@@ -60,6 +60,7 @@ export class MiniCart extends Component {
 
   handleItemsUpdate = async () => {
     const clientOnlyItems = this.getClientOnlyItems()
+    console.log(clientOnlyItems)
     if (clientOnlyItems.length && !this.state.updatingOrderForm) {
       return this.handleItemsDifference(clientOnlyItems)
     }

--- a/react/linkState/mutations.js
+++ b/react/linkState/mutations.js
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag'
+
+export const updateItemsMutation = gql`
+  mutation updateItems($items: [MinicartItem]) {
+    updateItems(items: $items) @client
+  }
+`
+
+export const updateOrderFormMutation = gql`
+  mutation updateOrderForm($orderForm: [OrderForm]) {
+    updateOrderForm(orderForm: $orderForm) @client
+  }
+`

--- a/react/linkState/queries.js
+++ b/react/linkState/queries.js
@@ -1,0 +1,93 @@
+import gql from 'graphql-tag'
+
+export const fullMinicartQuery = gql`
+  query {
+    minicart @client {
+      items {
+        id
+        name
+        imageUrl
+        detailUrl
+        skuName
+        quantity
+        sellingPrice
+        listPrice
+        seller
+        index
+        parentItemIndex
+        parentAssemblyBinding
+      }
+      orderForm {
+        cacheId
+        orderFormId
+        value
+        totalizers {
+          id
+          name
+          value
+        }
+        shippingData {
+          address {
+            id
+            neighborhood
+            complement
+            number
+            street
+            postalCode
+            city
+            reference
+            addressName
+            addressType
+          }
+          availableAddresses {
+            id
+            neighborhood
+            complement
+            number
+            street
+            postalCode
+            city
+            reference
+            addressName
+            addressType
+          }
+        }
+        clientProfileData {
+          email
+          firstName
+        }
+        storePreferencesData {
+          countryCode
+          currencyCode
+          timeZone
+        }
+        itemMetadata {
+          items {
+            id
+            name
+            skuName
+            productId
+            refId
+            ean
+            imageUrl
+            detailUrl
+            assemblyOptions {
+              id
+              name
+              required
+              composition {
+                minQuantity
+                maxQuantity
+                items {
+                  maxQuantity
+                  initialQuantity
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/react/linkState/queries.js
+++ b/react/linkState/queries.js
@@ -4,6 +4,7 @@ export const fullMinicartQuery = gql`
   query {
     minicart @client {
       items {
+        upToDate
         id
         name
         imageUrl

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -25,6 +25,36 @@ export const MiniCartPropTypes = {
   showSku: PropTypes.bool,
   /* Set the visibility of the Quantity Selector */
   enableQuantitySelector: PropTypes.bool,
+  /* The orderForm object */
+  orderForm: PropTypes.shape({
+    /* Order form id */
+    orderFormId: PropTypes.string,
+    /* Total price of the order */
+    value: PropTypes.number,
+    /* Items in the mini cart */
+    items: PropTypes.arrayOf(PropTypes.object),
+    /* Shipping Address */
+    shippingData: PropTypes.shape({
+      address: PropTypes.shape({
+        addressName: PropTypes.string,
+        addressType: PropTypes.string,
+        city: PropTypes.string,
+        complement: PropTypes.string,
+        country: PropTypes.string,
+        id: PropTypes.string,
+        neighborhood: PropTypes.string,
+        number: PropTypes.string,
+        postalCode: PropTypes.string,
+        receiverName: PropTypes.string,
+        reference: PropTypes.string,
+        state: PropTypes.string,
+        street: PropTypes.string,
+        userId: PropTypes.string,
+      }),
+      /* Available Addresses */
+      availableAddresses: PropTypes.arrayOf(PropTypes.object),
+    }),
+  }).isRequired,
   /* Max quantity for the Quantity Selector */
   maxQuantity: PropTypes.number,
   /* Set the shipping fee visibility */

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import { contextPropTypes } from 'vtex.store-resources/OrderFormContext'
 
 export const MiniCartPropTypes = {
   /* Set the minicart type */
@@ -28,8 +27,6 @@ export const MiniCartPropTypes = {
   enableQuantitySelector: PropTypes.bool,
   /* Max quantity for the Quantity Selector */
   maxQuantity: PropTypes.number,
-  /* Products in the cart */
-  orderFormContext: contextPropTypes,
   /* Set the shipping fee visibility */
   showShippingCost: PropTypes.bool,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

The orderForm can be queried from the LinkState. No need to get it from the server.

#### What problem is this solving?

First, we want to delete the orderFormContext. To do that, we need to put the orderForm somewhere all our apps can find. This is the LinkState.

#### How should this be manually tested?

[Access the workspace](https://linkstate--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
