### PR TITLE
Change product summary type to inlinePrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Use `inlinePrice` product summary type.
+
 ## [2.12.1] - 2019-03-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.13.0] - 2019-03-13
+
 ### Changed
 
 - Use `inlinePrice` product summary type.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -214,8 +214,10 @@ class MiniCartContent extends Component {
     const classes = classNames(`${minicart.content} overflow-x-hidden pa1`, {
       [`${minicart.contentSmall} bg-base`]: !isSizeLarge,
       [`${minicart.contentLarge}`]: isSizeLarge,
-      'overflow-y-scroll': itemsToShow.length > MIN_ITEMS_TO_SCROLL && !isSizeLarge,
-      'overflow-y-hidden': itemsToShow.length <= MIN_ITEMS_TO_SCROLL && !isSizeLarge,
+      'overflow-y-scroll':
+        itemsToShow.length > MIN_ITEMS_TO_SCROLL && !isSizeLarge,
+      'overflow-y-hidden':
+        itemsToShow.length <= MIN_ITEMS_TO_SCROLL && !isSizeLarge,
     })
 
     return (
@@ -244,7 +246,7 @@ class MiniCartContent extends Component {
                   showBorders
                   product={this.createProductShapeFromItem(item)}
                   name={item.name}
-                  displayMode="inline"
+                  displayMode="inlinePrice"
                   showListPrice={false}
                   showBadge={false}
                   showInstallments={false}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change product summary type to a specific of minicart.

In conjunction with [this](https://github.com/vtex-apps/product-summary/pull/125) PR

#### How should this be manually tested?
[Access this workspace](https://theoo--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
