### PR TITLE
Fix props passed to addToCart event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix props passed to `addToCart` event. 
+
 ## [2.16.0] - 2019-04-24
 ### Changed
 - Scope messages by domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.16.1] - 2019-04-30
+
 ### Fixed
 - Fix props passed to `addToCart` event. 
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/index.js
+++ b/react/index.js
@@ -37,7 +37,7 @@ const DEFAULT_ICON_CLASSES = 'gray'
  * Minicart component
  */
 class MiniCart extends Component {
-  static propTypes = { 
+  static propTypes = {
     ...MiniCartPropTypes,
     intl: intlShape.isRequired,
     showToast: PropTypes.func.isRequired,
@@ -94,10 +94,13 @@ class MiniCart extends Component {
         })
       }
       const addItemsResponse = await this.addItems(pickProps(itemsToAdd))
-      itemsToAdd.length > 0 && this.props.push({
+
+      if (itemsToAdd.length > 0) {
+        this.props.push({
           event: 'addToCart',
-          items: itemsToAdd,
+          items: map(this.getAddToCartEventItems, itemsToAdd),
         })
+      }
       const newModifiedItems = this.getModifiedItemsOnly()
       if (newModifiedItems.length > 0) {
         // If there are new modified items in cart, recursively call this function to send requests to server
@@ -179,6 +182,15 @@ class MiniCart extends Component {
     return items.filter(shouldShowItem)
   }
 
+  getAddToCartEventItems = ({ id: skuId, skuName: variant, sellingPrice: price, ...restSkuItem }) => {
+    return {
+      skuId,
+      variant,
+      price,
+      ...pick(['brand', 'name', 'quantity'], restSkuItem)
+    }
+  }
+
   render() {
     const { openContent } = this.state
     const {
@@ -248,7 +260,7 @@ class MiniCart extends Component {
                 <span
                   className={`${
                     minicart.badge
-                  } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+                    } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
                 >
                   {quantity}
                 </span>
@@ -268,15 +280,15 @@ class MiniCart extends Component {
               {miniCartContent}
             </Sidebar>
           ) : (
-            openContent && (
-              <Popup
-                onOutsideClick={this.handleUpdateContentVisibility}
-                buttonOffsetWidth={this.iconRef.offsetWidth}
-              >
-                {miniCartContent}
-              </Popup>
-            )
-          ))}
+              openContent && (
+                <Popup
+                  onOutsideClick={this.handleUpdateContentVisibility}
+                  buttonOffsetWidth={this.iconRef.offsetWidth}
+                >
+                  {miniCartContent}
+                </Popup>
+              )
+            ))}
       </aside>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Rename props of items passed to the `addToCart` event.

#### What problem is this solving?
The `google-tag-manager` expected [props](https://github.com/vtex-apps/google-tag-manager/blob/feb541f2d6da60ea8d3a27eb1a0b99cb406f7b01/react/index.tsx#L56) with different names and was getting undefined.


#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
