### PR TITLE
Allow users to add an item to cart when there is no network connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.17.0] - 2019-05-08
 ### Added
 - Add offline minicart logic allowing users to add an item to the cart when there is no network connection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add offline minicart logic allowing users to add an item to the cart when there is no network connection.
 
 ## [2.16.3] - 2019-05-01
 ### Fixed
@@ -16,7 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use `react-portal` to add Popup and Sidebar on the top level of the body.
 
 ## [2.16.1] - 2019-04-30
-
 ### Fixed
 - Fix props passed to `addToCart` event. 
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/index.js
+++ b/react/index.js
@@ -214,7 +214,6 @@ class MiniCart extends Component {
     const prevOrderForm = path(['data', 'orderForm'], prevProps)
     const orderForm = path(['data', 'orderForm'], this.props)
     if (!prevOrderForm && orderForm) {
-      console.log('handleOrderFormUpdate')
       await this.props.updateOrderForm(orderForm)
     }
   }
@@ -357,13 +356,15 @@ class MiniCart extends Component {
                   <span
                     className={`${
                       minicart.badge
-                      } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+                    } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
                   >
                     {quantity}
                   </span>
                 )}
               </span>
-              {iconLabel && <span className={iconLabelClasses}>{iconLabel}</span>}
+              {iconLabel && (
+                <span className={iconLabelClasses}>{iconLabel}</span>
+              )}
             </span>
           </Button>
           {!hideContent &&
@@ -381,9 +382,8 @@ class MiniCart extends Component {
                 <Popup onOutsideClick={this.handleUpdateContentVisibility}>
                   {miniCartContent}
                 </Popup>
-                )
-            ))
-          }
+              )
+            ))}
         </div>
       </aside>
     )

--- a/react/index.js
+++ b/react/index.js
@@ -119,7 +119,8 @@ class MiniCart extends Component {
       await this.handleItemsUpdate()
       this.handleOrderFormUpdate(prevProps)
       if (localStorage) {
-        localStorage.clear()
+        localStorage.removeItem('minicart')
+        localStorage.removeItem('orderForm')
       }
     } else {
       this.saveDataIntoLocalStorage()

--- a/react/localState/index.js
+++ b/react/localState/index.js
@@ -1,4 +1,4 @@
-import { head, mergeDeepRight, values } from 'ramda'
+import { identity, head, mergeDeepRight, values } from 'ramda'
 
 import {
   updateOrderFormShipping,
@@ -48,7 +48,9 @@ export default function(client) {
           minicart: { items: prevItems },
         } = cache.readQuery({ query })
 
-        const newItems = items.map(item => mapToMinicartItem({ ...item, localStatus: ITEMS_STATUS.MODIFIED  }))
+        const newItems = items.map(item =>
+          mapToMinicartItem({ ...item, localStatus: ITEMS_STATUS.MODIFIED })
+        )
         const writeItems = [...JSON.parse(prevItems), ...newItems]
         cache.writeData({
           data: {
@@ -74,12 +76,20 @@ export default function(client) {
         for (const newItem of cleanNewItems) {
           const { index } = newItem
           const prevItem = prevItemsParsed[index]
-          items[index] = mapToMinicartItem(mergeDeepRight(prevItem, { ...newItem, localStatus: ITEMS_STATUS.MODIFIED }))
+          items[index] = mapToMinicartItem(
+            mergeDeepRight(prevItem, {
+              ...newItem,
+              localStatus: ITEMS_STATUS.MODIFIED,
+            })
+          )
         }
 
         cache.writeData({
           data: {
-            minicart: { __typename: 'Minicart', items: JSON.stringify(items) },
+            minicart: {
+              __typename: 'Minicart',
+              items: JSON.stringify(items.filter(identity)),
+            },
           },
         })
         return items
@@ -113,13 +123,19 @@ export default function(client) {
         const prevItemsParsed = JSON.parse(prevItems)
         const itemsWithStatus = prevItemsParsed.map(item => {
           if (item.localStatus === ITEMS_STATUS.MODIFIED) {
-            return mapToMinicartItem({ ...item, localStatus: ITEMS_STATUS.WAITING_SERVER })
+            return mapToMinicartItem({
+              ...item,
+              localStatus: ITEMS_STATUS.WAITING_SERVER,
+            })
           }
           return mapToMinicartItem(item)
         })
         cache.writeData({
           data: {
-            minicart: { __typename: 'Minicart', items: JSON.stringify(itemsWithStatus) },
+            minicart: {
+              __typename: 'Minicart',
+              items: JSON.stringify(itemsWithStatus),
+            },
           },
         })
         return itemsWithStatus

--- a/react/localState/mutations.js
+++ b/react/localState/mutations.js
@@ -1,5 +1,11 @@
 import gql from 'graphql-tag'
 
+export const addToCartMutation = gql`
+  mutation addToCart($items: [MinicartItem]) {
+    addToCart(items: $items) @client
+  }
+`
+
 export const updateItemsMutation = gql`
   mutation updateItems($items: [MinicartItem]) {
     updateItems(items: $items) @client


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says.

#### What problem is this solving?

Users couldn't add items to cart when there was no internet connection but now the item is added and will be sent to the server as soon as the user has internet.

**Important: UI will be updated to let the users know what is going on. [See more...](https://www.figma.com/file/JSoQWW4BzI3N4DDq9MC8wF4W/PWA-ADMIN?node-id=224%3A3130)**

#### How should this be manually tested?

[Access the workspace](https://pwa--storecomponents.myvtex.com/) and add an item when offline.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/57159436-46c36300-6dbc-11e9-8879-ff256641672e.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
