### PR TITLE
Fix total purchase value when product is unavailable for shipping in the selected address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.18.3] - 2019-05-20
 ### Fixed
 - Fix total purchase value when the product is unavailable for shipping in the selected address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix total purchase value when address is unavailable.
+- Fix total purchase value when the product is unavailable for shipping in the selected address.
 
 ## [2.18.2] - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix total purchase value when address is unavailable.
 
 ## [2.18.2] - 2019-05-15
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -66,8 +66,9 @@ class MiniCartContent extends Component {
     return totalizer && totalizer.value / 100
   }
 
-  calculateDiscount = (items, totalPrice) =>
-    this.sumItemsPrice(items) - totalPrice
+  calculateDiscount = (items, totalPrice) => 
+    totalPrice == 0 ? totalPrice : this.sumItemsPrice(items) - totalPrice
+    
 
   handleItemRemoval = async ({ id, cartIndex }) => {
     const { updateItems } = this.props
@@ -101,6 +102,9 @@ class MiniCartContent extends Component {
       0
     )
   }
+
+  calculateTotalValue = orderForm =>
+    getShippingCost(orderForm) ? this.sumItemsPrice(orderForm.items) : orderForm.value 
 
   createProductShapeFromItem = item => ({
     productName: item.name,
@@ -214,7 +218,7 @@ class MiniCartContent extends Component {
         <MiniCartFooter
           shippingCost={this.getShippingCost(orderForm)}
           isUpdating={this.isUpdating}
-          totalValue={orderForm.value}
+          totalValue={this.calculateTotalValue(orderForm)}
           discount={this.calculateDiscount(orderForm.items, orderForm.value)}
           buttonLabel={label}
           isSizeLarge={isSizeLarge}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -66,8 +66,8 @@ class MiniCartContent extends Component {
     return totalizer && totalizer.value / 100
   }
 
-  calculateDiscount = (items, totalPrice) => 
-    totalPrice == 0 ? totalPrice : this.sumItemsPrice(items) - totalPrice
+  calculateDiscount = (items) =>
+    items.reduce((sum, { listPrice, sellingPrice, quantity }) => sum + (listPrice - sellingPrice) * quantity, 0)
 
   handleItemRemoval = async ({ id, cartIndex }) => {
     const { updateItems } = this.props
@@ -103,7 +103,7 @@ class MiniCartContent extends Component {
   }
 
   calculateTotalValue = orderForm =>
-    this.getShippingCost(orderForm) ?  orderForm.value  : this.sumItemsPrice(orderForm.items)
+    this.getShippingCost(orderForm) ? orderForm.value : this.sumItemsPrice(orderForm.items)
 
   createProductShapeFromItem = item => ({
     productName: item.name,
@@ -218,7 +218,7 @@ class MiniCartContent extends Component {
           shippingCost={this.getShippingCost(orderForm)}
           isUpdating={this.isUpdating}
           totalValue={this.calculateTotalValue(orderForm)}
-          discount={this.calculateDiscount(orderForm.items, orderForm.value)}
+          discount={this.calculateDiscount(orderForm.items)}
           buttonLabel={label}
           isSizeLarge={isSizeLarge}
           labelDiscount={labelDiscount}

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -68,7 +68,6 @@ class MiniCartContent extends Component {
 
   calculateDiscount = (items, totalPrice) => 
     totalPrice == 0 ? totalPrice : this.sumItemsPrice(items) - totalPrice
-    
 
   handleItemRemoval = async ({ id, cartIndex }) => {
     const { updateItems } = this.props
@@ -104,7 +103,7 @@ class MiniCartContent extends Component {
   }
 
   calculateTotalValue = orderForm =>
-    getShippingCost(orderForm) ? this.sumItemsPrice(orderForm.items) : orderForm.value 
+    this.getShippingCost(orderForm) ?  orderForm.value  : this.sumItemsPrice(orderForm.items)
 
   createProductShapeFromItem = item => ({
     productName: item.name,

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -46,7 +46,7 @@ class MiniCartContent extends Component {
 
   sumItemsPrice = items =>
     items.reduce(
-      (sum, { listPrice, quantity }) => sum + listPrice * quantity,
+      (sum, { sellingPrice, quantity }) => sum + sellingPrice * quantity,
       0
     )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
as the title says.

#### What problem is this solving?
When a user add to cart some product unavailable for shipping in the selected address, the total purchase value turn into `0,00`
[full description](https://app.clubhouse.io/vtex-dev/story/10690/minicart-show-free-products-when-not-available-for-address-country).

#### How should this be manually tested?
1. [Access this workspace](https://mariana--storecomponents.myvtex.com/)
2. Add a product in the cart and go to the checkout
4. Open console and paste this `vtexjs.checkout.sendAttachment('shippingData', { address: { ...vtexjs.checkout.orderForm.shippingData.address, postalCode: 'ABC', country: 'GBR' } })`
3. Back to the store and open minicart. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
