### PR TITLE
Fix offline cart behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add Lint to repo, fix basic issues.
 
+### Fixed
+- Fixed the case when an item is added offline and the user closes and then accesses the store again still offline.
+
 ## [2.18.0] - 2019-05-14
 ### Changed
 - `isOpen` state is now coming from Apollo Local State.
 
 ## [2.17.1] - 2019-05-08
-
 ### Fixed
 - Export MiniCart schema and create test case for it. (Releasing again.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.18.1] - 2019-05-15
 ### Changed
 - Add Lint to repo, fix basic issues.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/index.js
+++ b/react/index.js
@@ -61,6 +61,14 @@ class MiniCart extends Component {
     }
   }
 
+  get orderForm() {
+    return pathOr(
+      path(['linkState', 'orderForm'], this.props),
+      ['data', 'orderForm'],
+      this.props
+    )
+  }
+
   saveDataIntoLocalStorage = () => {
     const clientItems = this.getModifiedItemsOnly()
     const clientOrderForm = pathOr(
@@ -139,7 +147,7 @@ class MiniCart extends Component {
     if (
       modifiedItems.length &&
       !this.state.updatingOrderForm &&
-      this.props.data.orderForm
+      this.orderForm
     ) {
       return this.handleItemsDifference(modifiedItems)
     }
@@ -202,7 +210,7 @@ class MiniCart extends Component {
       // TODO: Toast error message into Alert
       console.error(err)
       // Rollback items and orderForm
-      const orderForm = path(['data', 'orderForm'], this.props)
+      const orderForm = this.orderForm
       showToast({
         message: intl.formatMessage({ id: 'store/minicart.checkout-failure' }),
       })
@@ -220,9 +228,7 @@ class MiniCart extends Component {
   }
 
   addItems = items => {
-    const {
-      orderForm: { orderFormId },
-    } = this.props.data
+    const { orderFormId } = this.orderForm
     if (items.length) {
       return this.props.addToCart({
         variables: { orderFormId, items },
@@ -231,9 +237,7 @@ class MiniCart extends Component {
   }
 
   updateItems = items => {
-    const {
-      orderForm: { orderFormId },
-    } = this.props.data
+    const { orderFormId } = this.orderForm
     if (items.length) {
       return this.props.updateItems({
         variables: { orderFormId, items },

--- a/react/index.js
+++ b/react/index.js
@@ -62,14 +62,14 @@ class MiniCart extends Component {
   }
 
   saveDataIntoLocalStorage = () => {
-    if (localStorage) {
-      const clientItems = this.getModifiedItemsOnly()
+    const clientItems = this.getModifiedItemsOnly()
+    const clientOrderForm = pathOr(
+      path(['data', 'orderForm'], this.props),
+      ['linkState', 'orderForm'],
+      this.props
+    )
+    if (localStorage && clientItems.length) {
       localStorage.setItem('minicart', JSON.stringify(clientItems))
-      const clientOrderForm = pathOr(
-        path(['data', 'orderForm'], this.props),
-        ['linkState', 'orderForm'],
-        this.props
-      )
       localStorage.setItem('orderForm', JSON.stringify(clientOrderForm))
     }
   }
@@ -117,7 +117,7 @@ class MiniCart extends Component {
   async componentDidUpdate(prevProps) {
     if (!this.state.offline) {
       await this.handleItemsUpdate()
-      this.handleOrderFormUpdate(prevProps)
+      await this.handleOrderFormUpdate(prevProps)
       if (localStorage) {
         localStorage.removeItem('minicart')
         localStorage.removeItem('orderForm')


### PR DESCRIPTION
#### What is the purpose of this pull request?

The offline cart needs to behavior gracefully when the user adds an item to the cart while offline, then closes the app and reopens it still offline.

#### What problem is this solving?

Before, when reopening the app, the items were set to an empty array.

#### How should this be manually tested?

1. [Access the workspace](http://offline--storecomponents.myvtex.com)
2. Go offline
3. Add an item to cart (the item should be there)
4. Close the tab/PWA app
5. Reopen it while offline (the item should still be there)
6. Go online (orderform should be updated and the item added)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
