### PR TITLE
Pass UTM params to Checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ docs/_book/
 npm-debug.log
 .build/
 lib
-.eslintrc
 *.orig
 react/package-lock.json
 package-lock.json
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "es5"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Pass UTM Source, UTM Campaign and UTMI Campaign when linking to checkout.
+
 ## [2.18.3] - 2019-05-20
 ### Fixed
 - Fix total purchase value when the product is unavailable for shipping in the selected address.

--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,6 @@
     "vtex.store-icons": "0.x",
     "vtex.pixel-manager": "0.x",
     "vtex.react-portal": "0.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "vtex-react"
+}

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -8,7 +8,32 @@ import PropTypes from 'prop-types'
 import { MiniCartPropTypes } from '../propTypes'
 import minicart from '../minicart.css'
 
-const handleClickButton = () => location.assign('/checkout/#/cart')
+const handleClickButton = () => {
+  try {
+    const segment = JSON.parse(window.atob(__RUNTIME__.segmentToken))
+    const utmParams = [
+      { key: 'utm_campaign', value: segment.utm_campaign },
+      { key: 'utm_source', value: segment.utm_source },
+      { key: 'utmi_campaign', value: segment.utmi_campaign },
+    ]
+
+    const params = utmParams.reduce((acc, param) => {
+      if (param.value) {
+        if (acc === '') {
+          acc = '?'
+        }
+
+        acc +=
+          encodeURIComponent(param.key) + '=' + encodeURIComponent(param.value)
+      }
+      return acc
+    }, '')
+
+    location.assign('/checkout/' + params)
+  } catch (e) {
+    location.assign('/checkout/')
+  }
+}
 
 const MiniCartFooter = ({
   shippingCost,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Pass UTM Source, UTM Campaign and UTMI Campaign to Checkout URL.

#### What problem is this solving?

Tracking of campaigns.

#### How should this be manually tested?

1. Open: https://breno--storecomponents.myvtex.com?utm_source=TEST
2. Add a product to cart
3. Go to cart and check if the URL contains the `?utm_source=TEST`.

#### Screenshots or example usage

n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
