### PR TITLE
Fix offline minicart adding repeated item when user navigates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.20.1-beta] - 2019-06-12
 ### Fixed
 
 - Offline Minicart adding repeated items when user navigates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Offline Minicart adding repeated items when user navigates.
 
 ## [2.20.0] - 2019-05-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.20.0",
+  "version": "2.20.1-beta",
   "defaultLocale": "pt-BR",
   "builders": {
     "messages": "1.x",

--- a/react/index.js
+++ b/react/index.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import PropTypes from 'prop-types'
-import { map, partition, path, pathOr, pick } from 'ramda'
+import { map, partition, path, pathOr, pick, isEmpty } from 'ramda'
 import React, { Component, useEffect } from 'react'
 import { Button, withToast } from 'vtex.styleguide'
 import { isMobile } from 'react-device-detect'
@@ -108,7 +108,8 @@ class MiniCart extends Component {
         await this.props.updateOrderForm(orderForm)
         localStorage.removeItem('orderForm')
       }
-      if (minicart && minicart.length) {
+      if (minicart && minicart.length && 
+        isEmpty(pathOr([], ['linkState', 'minicartItems'], this.props))) {
         await this.props.addToLinkStateCart(minicart)
         localStorage.removeItem('minicart')
       }

--- a/react/index.js
+++ b/react/index.js
@@ -52,12 +52,13 @@ class MiniCart extends Component {
 
   state = {
     updatingOrderForm: false,
-    offline: false,
+    offline: typeof navigator !== 'undefined' ? !pathOr(true, ['onLine'], navigator) : false,
   }
 
   updateStatus = () => {
     if (navigator) {
-      this.setState({ offline: !pathOr(true, ['onLine'], navigator) })
+      const offline = !pathOr(true, ['onLine'], navigator)
+      this.setState({ offline })
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Resolves #151 

`updateOrderForm` can update the **minicartItems** _LinkState_ [here](https://github.com/vtex-apps/minicart/blob/c827902ce9c36f42955ddd529989086b94187081/react/localState/index.js#L209), but   [`addToLinkStateCart`](https://github.com/vtex-apps/minicart/blob/c827902ce9c36f42955ddd529989086b94187081/react/index.js#L112) was not checking if this happens and would repeat the items in the minicart.

My solution is to check if the _linkState_ of the **minicartItems** is empty when the component is mounted.

#### What problem is this solving?
As the title says.

#### How should this be manually tested?
[workspace](https://thay--storecomponents.myvtex.com/)

1. Open the store and navigate through some products
2. Turn off the internet connection
3. Add an item to the minicart
4. Navigate to a page that has been navigated online before.
5. Check if adds repeated items in the minicart.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
