### PR TITLE
Add notification alerts for offline minicart features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Offline Minicart adding repeated items when user navigates.
 
+### Changed
+- Pass prop `isPartial` to the product summary extension point.
+
 ## [2.21.2] - 2019-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Error and warning alerts in offline minicart implementation.
+
 ### Fixed
 - Offline Minicart adding repeated items when user navigates.
 
 ### Changed
 - Pass prop `isPartial` to the product summary extension point.
+- Toast to Styleguide Alert in error messages.
 
 ## [2.21.2] - 2019-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Offline Minicart adding repeated items when user navigates.
 
 ## [2.21.2] - 2019-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-
 - Offline Minicart adding repeated items when user navigates.
 
 ## [2.21.2] - 2019-07-01

--- a/messages/context.json
+++ b/messages/context.json
@@ -16,6 +16,6 @@
   "store/minicart.shipping-cost": "store/minicart.shipping-cost",
   "store/minicart.checkout-failure": "Message showed when there is a problem to a request to the server.",
   "store/minicart.item-added-offline": "Message showed when an item is added offline.",
-  "store/minicart.offline-items-sycronized": "Message showed when an offline item is successfully syncronized online.",
-  "store/minicart.error-syncronizing-offline-items": "Message showed when an offline item couldn't be syncronized online."
+  "store/minicart.offline-items-synchronized": "Message showed when an offline item is successfully synchronized online.",
+  "store/minicart.error-synchronizing-offline-items": "Message showed when an offline item couldn't be synchronized online."
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -15,7 +15,7 @@
   "store/minicart.error-removal": "store/minicart.error-removal",
   "store/minicart.shipping-cost": "store/minicart.shipping-cost",
   "store/minicart.checkout-failure": "Message showed when there is a problem to a request to the server.",
-  "store/minicart.alert-item-added-offline": "Message showed when an item is only added offline.",
-  "store/minicart.alert-item-added-online": "Message showed when an offline item is successfully send to the server.",
-  "store/minicart.alert-error-item-offline": "Message showed when the item couldn't be added in the server."
+  "store/minicart.item-added-offline": "Message showed when an item is added offline.",
+  "store/minicart.offline-items-sycronized": "Message showed when an offline item is successfully syncronized online.",
+  "store/minicart.error-syncronizing-offline-items": "Message showed when an offline item couldn't be syncronized online."
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -14,5 +14,8 @@
   "store/minicart-content-footer-discount": "store/minicart-content-footer-discount",
   "store/minicart.error-removal": "store/minicart.error-removal",
   "store/minicart.shipping-cost": "store/minicart.shipping-cost",
-  "store/minicart.checkout-failure": "Message showed when there is a problem to a request to the server."
+  "store/minicart.checkout-failure": "Message showed when there is a problem to a request to the server.",
+  "store/minicart.alert-item-added-offline": "Message showed when an item is only added offline.",
+  "store/minicart.alert-item-added-online": "Message showed when an offline item is successfully send to the server.",
+  "store/minicart.alert-error-item-offline": "Message showed when the item couldn't be added in the server."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,5 +14,8 @@
     "store/minicart-content-footer-discount": "Save",
     "store/minicart.error-removal": "Item removal failed, please try again",
     "store/minicart.shipping-cost": "Total shipping cost",
-    "store/minicart.checkout-failure": "Something went wrong. Please, try again."
+    "store/minicart.checkout-failure": "Something went wrong. Please, try again.",
+    "store/minicart.alert-item-added-offline": "Item added offline and will be synchronized when connection returns.",
+    "store/minicart.alert-item-added-online": "Items successfully synchronized.",
+    "store/minicart.alert-error-item-offline": "Couldn't syncronize your items."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,6 @@
     "store/minicart.shipping-cost": "Total shipping cost",
     "store/minicart.checkout-failure": "Something went wrong. Please, try again.",
     "store/minicart.item-added-offline": "Item added offline. Will be syncronized when connection is established.",
-    "store/minicart.offline-items-sycronized": "Offline items syncronized successfully.",
-    "store/minicart.error-syncronizing-offline-items": "Something went wrong when syncronizing offline items."
+    "store/minicart.offline-items-synchronized": "Offline items synchronized successfully.",
+    "store/minicart.error-synchronizing-offline-items": "Something went wrong when synchroning offline items."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,7 @@
     "store/minicart.error-removal": "Item removal failed, please try again",
     "store/minicart.shipping-cost": "Total shipping cost",
     "store/minicart.checkout-failure": "Something went wrong. Please, try again.",
-    "store/minicart.alert-item-added-offline": "Item added offline and will be synchronized when connection returns.",
-    "store/minicart.alert-item-added-online": "Items successfully synchronized.",
-    "store/minicart.alert-error-item-offline": "Couldn't syncronize your items."
+    "store/minicart.item-added-offline": "Item added offline. Will be syncronized when connection is established.",
+    "store/minicart.offline-items-sycronized": "Offline items syncronized successfully.",
+    "store/minicart.error-syncronizing-offline-items": "Something went wrong when syncronizing offline items."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,7 @@
     "store/minicart.error-removal": "Item removal failed, please try again",
     "store/minicart.shipping-cost": "Total shipping cost",
     "store/minicart.checkout-failure": "Something went wrong. Please, try again.",
-    "store/minicart.item-added-offline": "Item added offline. Will be syncronized when connection is established.",
+    "store/minicart.item-added-offline": "Item added offline. Will be synchronized when connection is established.",
     "store/minicart.offline-items-synchronized": "Offline items synchronized successfully.",
     "store/minicart.error-synchronizing-offline-items": "Something went wrong when synchroning offline items."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -16,6 +16,6 @@
     "store/minicart.shipping-cost": "Costo total del envío",
     "store/minicart.checkout-failure": "Algo salió mal. Por favor, inténtelo de nuevo. ",
     "store/minicart.item-added-offline": "Artículo añadido sin conexión. Se sincronizará cuando se establezca la conexión.",
-    "store/minicart.offline-items-sycronized": "Artículos sincronizados.",
-    "store/minicart.error-syncronizing-offline-items": "Algo salió mal durante la sincronización artículos."
+    "store/minicart.offline-items-synchronized": "Artículos sincronizados.",
+    "store/minicart.error-synchronizing-offline-items": "Algo salió mal durante la sincronización artículos."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -14,5 +14,8 @@
     "store/minicart-content-footer-discount": "Guarde",
     "store/minicart.error-removal": "Falló la eliminación del artículo, por favor intente de nuevo",
     "store/minicart.shipping-cost": "Costo total del envío",
-    "store/minicart.checkout-failure": "Algo salió mal. Por favor, inténtelo de nuevo. "
+    "store/minicart.checkout-failure": "Algo salió mal. Por favor, inténtelo de nuevo. ",
+    "store/minicart.item-added-offline": "Artículo añadido sin conexión. Se sincronizará cuando se establezca la conexión.",
+    "store/minicart.offline-items-sycronized": "Artículos sincronizados.",
+    "store/minicart.error-syncronizing-offline-items": "Algo salió mal durante la sincronización artículos."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -16,6 +16,6 @@
     "store/minicart.shipping-cost": "Custo de entrega",
     "store/minicart.checkout-failure": "Algo deu errado. Por favor, tente novamente.",
     "store/minicart.item-added-offline": "Item adicionado offline e será sincronizado assim que estabelecer conexão.",
-    "store/minicart.offline-items-sycronized": "Itens offiline foram sincronizados.",
-    "store/minicart.error-syncronizing-offline-items": "Algo deu errado ao sincronizar os itens offline."
+    "store/minicart.offline-items-synchronized": "Itens offiline foram sincronizados.",
+    "store/minicart.error-synchronizing-offline-items": "Algo deu errado ao sincronizar os itens offline."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -14,5 +14,8 @@
     "store/minicart-content-footer-discount": "Economize",
     "store/minicart.error-removal": "A remoção do item falhou, por favor tente novamente",
     "store/minicart.shipping-cost": "Custo de entrega",
-    "store/minicart.checkout-failure": "Algo deu errado. Por favor, tente novamente."
+    "store/minicart.checkout-failure": "Algo deu errado. Por favor, tente novamente.",
+    "store/minicart.item-added-offline": "Item adicionado offline e será sincronizado assim que estabelecer conexão.",
+    "store/minicart.offline-items-sycronized": "Itens offiline foram sincronizados.",
+    "store/minicart.error-syncronizing-offline-items": "Algo deu errado ao sincronizar os itens offline."
 }

--- a/react/.eslintrc.json
+++ b/react/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "vtex-react",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "jest": true
+  }
+}

--- a/react/components/AlertMessage.js
+++ b/react/components/AlertMessage.js
@@ -4,15 +4,18 @@ import React, { Fragment } from 'react'
 
 
 const AlertMessage = ({ message, type = "warning", onClose }) => {
+
   const canUsePortal = () => document && document.body
-  
-  return(
+
+  return (
     <Fragment>
-      { message && canUsePortal() &&
+      {message && canUsePortal() &&
         createPortal(
-          <Alert type={type} onClose={ onClose }>
-            { message }
-          </Alert>,
+          <div className="fixed bottom-1 left-1 z-max">
+            <Alert type={type} onClose={onClose}>
+              {message}
+            </Alert>
+          </div>,
           document.body
         )
       }

--- a/react/components/AlertMessage.js
+++ b/react/components/AlertMessage.js
@@ -12,7 +12,7 @@ const AlertMessage = ({ message, type = "warning", onClose }) => {
       {message && canUsePortal() &&
         createPortal(
           <div className="fixed bottom-1 left-1 z-max">
-            <Alert type={type} onClose={onClose}>
+            <Alert type={type} onClose={onClose} autoClose={5000}>
               {message}
             </Alert>
           </div>,

--- a/react/components/AlertMessage.js
+++ b/react/components/AlertMessage.js
@@ -2,16 +2,14 @@ import { Alert } from 'vtex.styleguide'
 import { createPortal } from 'react-dom'
 import React, { Fragment } from 'react'
 
-
 const AlertMessage = ({ message, type = "warning", onClose }) => {
-
   const canUsePortal = () => document && document.body
 
   return (
     <Fragment>
       {message && canUsePortal() &&
         createPortal(
-          <div className="fixed bottom-1 left-1 z-max">
+          <div className="fixed bottom-1 right-1 z-max">
             <Alert type={type} onClose={onClose} autoClose={5000}>
               {message}
             </Alert>

--- a/react/components/AlertMessage.js
+++ b/react/components/AlertMessage.js
@@ -1,0 +1,23 @@
+import { Alert } from 'vtex.styleguide'
+import { createPortal } from 'react-dom'
+import React, { Fragment } from 'react'
+
+
+const AlertMessage = ({ message, type = "warning", onClose }) => {
+  const canUsePortal = () => document && document.body
+  
+  return(
+    <Fragment>
+      { message && canUsePortal() &&
+        createPortal(
+          <Alert type={type} onClose={ onClose }>
+            { message }
+          </Alert>,
+          document.body
+        )
+      }
+    </Fragment>
+  )
+}
+
+export default AlertMessage

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -214,7 +214,7 @@ class MiniCartContent extends Component {
                   showInstallments={false}
                   showLabels={false}
                   actionOnClick={onClickAction}
-                  isPartial={item.localStatus === ITEMS_STATUS.MODIFIED}
+                  muted={item.localStatus === ITEMS_STATUS.MODIFIED}
                 />
               </section>
             </Fragment>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -214,7 +214,7 @@ class MiniCartContent extends Component {
                   showInstallments={false}
                   showLabels={false}
                   actionOnClick={onClickAction}
-                  isPartial={item.localState !== ITEMS_STATUS.NONE}
+                  isPartial={item.localStatus === ITEMS_STATUS.MODIFIED}
                 />
               </section>
             </Fragment>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -12,6 +12,7 @@ import { IconDelete } from 'vtex.store-icons'
 import { MiniCartPropTypes } from '../utils/propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
 
+import { ITEMS_STATUS } from '../localState/index'
 import { updateItemsMutation } from '../localState/mutations'
 import minicart from '../minicart.css'
 import MiniCartFooter from './MiniCartFooter'
@@ -213,6 +214,7 @@ class MiniCartContent extends Component {
                   showInstallments={false}
                   showLabels={false}
                   actionOnClick={onClickAction}
+                  isPartial={item.localState !== ITEMS_STATUS.NONE}
                 />
               </section>
             </Fragment>

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -153,9 +153,7 @@ class MiniCartContent extends Component {
 
   renderWithoutItems = label => (
     <div
-      className={`${
-        minicart.item
-      } pa9 flex items-center justify-center relative bg-base`}
+      className={`${minicart.item} pa9 flex items-center justify-center relative bg-base`}
     >
       <span className="t-body">{label}</span>
     </div>
@@ -237,9 +235,7 @@ class MiniCartContent extends Component {
 
   renderLoading = () => (
     <div
-      className={`${
-        minicart.item
-      } pa4 flex items-center justify-center relative bg-base`}
+      className={`${minicart.item} pa4 flex items-center justify-center relative bg-base`}
     >
       <Spinner />
     </div>

--- a/react/index.js
+++ b/react/index.js
@@ -2,8 +2,8 @@ import classNames from 'classnames'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import PropTypes from 'prop-types'
 import { map, partition, path, pathOr, pick, isEmpty } from 'ramda'
-import React, { Component, useEffect, Fragment, createPortal } from 'react'
-import { Button, withToast, Alert } from 'vtex.styleguide'
+import React, { Component, useEffect, Fragment } from 'react'
+import { Button, withToast } from 'vtex.styleguide'
 import { isMobile } from 'react-device-detect'
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { IconCart } from 'vtex.store-icons'
@@ -83,15 +83,10 @@ class MiniCart extends Component {
       ['linkState', 'orderForm'],
       this.props
     )
+    
     if (localStorage && clientItems.length) {
       localStorage.setItem('minicart', JSON.stringify(clientItems))
       localStorage.setItem('orderForm', JSON.stringify(clientOrderForm))
-      this.showAlert(
-        this.props.intl.formatMessage(
-          { id: 'store/minicart.item-added-offline' }
-        ),
-        'success'
-      )
     }
   }
 
@@ -139,18 +134,19 @@ class MiniCart extends Component {
     if (!this.state.offline) {
       await this.handleItemsUpdate()
       await this.handleOrderFormUpdate(prevProps)
-      if (localStorage) {
-        this.showAlert(
-          this.props.intl.formatMessage(
-            { id: 'store/minicart.offline-items-sycronized' }
-          ),
-          'success'
-        )
+      if (localStorage) {        
+        if(localStorage.getItem('minicart') != null) 
+          this.showAlert(
+            this.props.intl.formatMessage({id: 'store/minicart.offline-items-synchronized'}),
+            'success'
+          )
         localStorage.removeItem('minicart')
         localStorage.removeItem('orderForm')
       }
     } else {
       this.saveDataIntoLocalStorage()
+      if (prevProps.linkState.minicartItems.length != this.props.linkState.minicartItems.length)
+        this.showAlert(this.props.intl.formatMessage({ id: 'store/minicart.item-added-offline' }))
     }
   }
 
@@ -233,7 +229,7 @@ class MiniCart extends Component {
       const orderForm = this.orderForm
       this.showAlert(
         intl.formatMessage(
-          { id: 'store/minicart.error-syncronizing-offline-items' }
+          { id: 'store/minicart.checkout-failure' }
         ),
         'error'
       )
@@ -375,7 +371,7 @@ class MiniCart extends Component {
 
     return (
       <Fragment>
-        {alert.message &&
+        {alert && alert.message &&
           <AlertMessage message={alert.message} type={alert.type} onClose={this.handleCloseAlert}/>
         }
         <aside className={`${minicart.container} relative fr flex items-center`}>

--- a/react/index.js
+++ b/react/index.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import PropTypes from 'prop-types'
-import { map, partition, path, pathOr, pick } from 'ramda'
+import { map, partition, path, pathOr, pick, isEmpty } from 'ramda'
 import React, { Component, useEffect } from 'react'
 import { Button, withToast } from 'vtex.styleguide'
 import { isMobile } from 'react-device-detect'
@@ -108,7 +108,8 @@ class MiniCart extends Component {
         await this.props.updateOrderForm(orderForm)
         localStorage.removeItem('orderForm')
       }
-      if (minicart && minicart.length) {
+      if (minicart && minicart.length && 
+        isEmpty(pathOr([], ['linkState', 'minicartItems'], this.props))) {
         await this.props.addToLinkStateCart(minicart)
         localStorage.removeItem('minicart')
       }

--- a/react/index.js
+++ b/react/index.js
@@ -307,7 +307,6 @@ class MiniCart extends Component {
       type,
       hideContent,
       showShippingCost,
-      alertMessage,
       linkState: { minicartItems: items, orderForm, isOpen },
     } = this.props
 
@@ -348,8 +347,8 @@ class MiniCart extends Component {
 
     return (
       <Fragment>
-        {alertMessage && 
-          <AlertMessage message={alertMessage} onClose={this.handleCloseAlert}/>
+        {this.state.alertMessage &&
+          <AlertMessage message={this.state.alertMessage} onClose={this.handleCloseAlert}/>
         }
         <aside className={`${minicart.container} relative fr flex items-center`}>
           <div className="flex flex-column">

--- a/react/index.js
+++ b/react/index.js
@@ -52,12 +52,13 @@ class MiniCart extends Component {
 
   state = {
     updatingOrderForm: false,
-    offline: false,
+    offline: typeof navigator !== 'undefined' ? !pathOr(true, ['onLine'], navigator) : false,
   }
 
   updateStatus = () => {
     if (navigator) {
-      this.setState({ offline: !pathOr(true, ['onLine'], navigator) })
+      const offline = !pathOr(true, ['onLine'], navigator)
+      this.setState({ offline })
     }
   }
 

--- a/react/index.js
+++ b/react/index.js
@@ -342,10 +342,7 @@ class MiniCart extends Component {
     )
 
     return (
-      <aside
-        className={`${minicart.container} relative fr flex items-center`}
-        ref={e => (this.iconRef = e)}
-      >
+      <aside className={`${minicart.container} relative fr flex items-center`}>
         <div className="flex flex-column">
           <Button
             variation="tertiary"
@@ -357,9 +354,7 @@ class MiniCart extends Component {
                 <IconCart size={iconSize} />
                 {quantity > 0 && (
                   <span
-                    className={`${
-                      minicart.badge
-                    } c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+                    className={`${minicart.badge} c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
                   >
                     {quantity}
                   </span>

--- a/react/localState/index.js
+++ b/react/localState/index.js
@@ -20,7 +20,7 @@ export const ITEMS_STATUS = {
   WAITING_SERVER: 'WAITING_SERVER',
 }
 
-/* eslint-disable no-use-before-define */
+/* eslint-disable @typescript-eslint/no-use-before-define */
 
 // Need this for circular dependency
 
@@ -45,7 +45,7 @@ const mapAssemblyOptions = (options = {}) => ({
   __typename: 'AssemblyOptions',
 })
 
-/* eslint-enable no-use-before-define */
+/* eslint-enable @typescript-eslint/no-use-before-define */
 
 const mapToAddress = address => ({
   ...address,

--- a/react/package.json
+++ b/react/package.json
@@ -11,11 +11,13 @@
   "devDependencies": {
     "@vtex/test-tools": "^0.3.1",
     "apollo-cache-inmemory": "^1.5.1",
+    "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",
-    "eslint-config-vtex-react": "^4.0.0",
+    "eslint-config-vtex-react": "^4.1.0",
     "eslint-plugin-import": "2.16.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
+    "typescript": "^3.5.1",
     "waait": "^1.0.4"
   },
   "dependencies": {

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": ["es2017", "dom", "es2018.promise"],
+    "module": "es6",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "target": "es2017",
+    "typeRoots": ["node_modules/@types"],
+    "types": ["node", "jest", "graphql"]
+  },
+  "exclude": ["node_modules"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
+  "typeAcquisition": {
+    "enable": false
+  }
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1332,6 +1332,18 @@ axobject-query@^2.0.2:
   dependencies:
     ast-types-flow "0.0.7"
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-jest@^24.4.0, babel-jest@^24.5.0:
   version "24.5.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.5.0.tgz#0ea042789810c2bec9065f7c8ab4dc18e1d28559"
@@ -1909,7 +1921,7 @@ eslint-config-prettier@^4.0.0, eslint-config-prettier@^4.2.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-vtex-react@^4.0.0:
+eslint-config-vtex-react@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-vtex-react/-/eslint-config-vtex-react-4.1.0.tgz#ff3af3a9fbff717e42fa0d207e0344ec1ec19a0f"
   integrity sha512-DJJ4HQEAx4EVvJPE9zz52IlRbf+GL+Rscr50fDJQkM8UTUlndAHXCuYrqir1VvSps9+xvFNnc+LnwdjQv5dIlw==
@@ -2008,6 +2020,14 @@ eslint-plugin-react@^7.0.0:
     object.fromentries "^2.0.0"
     prop-types "^15.7.2"
     resolve "^1.10.1"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -4136,10 +4156,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.4:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
-  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^24.0.0:
   version "24.0.0"
@@ -5122,6 +5142,11 @@ typescript@^3.3.3333:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
   integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
+
+typescript@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add styleguide `alert` to notify events while synchronizing offline items.

- Alert when an item is only added offline
- Alert when an offline item was successfully send to the server
- Alert when occurs an error sending to the server

#### What problem is this solving?
#152 

#### How should this be manually tested?
[Workspace](http://alerts--storecomponents.myvtex.com)

#### Screenshots or example usage
<img width="1680" alt="Screen Shot 2019-06-27 at 17 17 22" src="https://user-images.githubusercontent.com/6867958/60297819-76e03b80-98ff-11e9-8179-e44b34a2ff4d.png">

<img width="1680" alt="Screen Shot 2019-06-27 at 16 49 53" src="https://user-images.githubusercontent.com/6867958/60297542-ce31dc00-98fe-11e9-8373-d185beaa92f3.png">

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
