### PR TITLE
Fix unable to remove items or update quantity when offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Pass prop `isPartial` to the product summary extension point.
 
+### Fixed
+- Quantity not updating and remove button not working on offline added item.
+
 ## [2.20.1-beta] - 2019-06-12
 ### Fixed
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -74,12 +74,12 @@ class MiniCartContent extends Component {
       0
     )
 
-  handleItemRemoval = async ({ id, cartIndex }) => {
-    const { updateItems } = this.props
+  handleItemRemoval = async ({ id }) => {
+    const { updateItems, itemsToShow } = this.props
     const updatedItems = [
       {
         id,
-        index: cartIndex,
+        index: itemsToShow.findIndex(product => product.id === id),
         quantity: 0,
       },
     ]
@@ -136,7 +136,9 @@ class MiniCartContent extends Component {
     },
     assemblyOptions: item.assemblyOptions,
     quantity: item.quantity,
-    cartIndex: item.cartIndex,
+    cartIndex:
+      item.cartIndex ||
+      this.props.itemsToShow.findIndex(product => product.id === item.id),
   })
 
   get isUpdating() {

--- a/react/localState/resolvers/updateItems.js
+++ b/react/localState/resolvers/updateItems.js
@@ -3,11 +3,9 @@ import { mergeDeepRight } from 'ramda'
 import { mapToMinicartItem, ITEMS_STATUS } from '../index'
 
 const updateItems = (cartItems, newItems) => {
-  // Items provided to this function MUST have a valid index property
-  const cleanNewItems = newItems.filter(({ index }) => index != null)
   const items = [...cartItems]
 
-  for (const newItem of cleanNewItems) {
+  for (const newItem of newItems) {
     const { index } = newItem
     const prevItem = cartItems[index]
     items[index] = mapToMinicartItem(


### PR DESCRIPTION
#### What is the purpose of this pull request?
remove check when updating items.

#### What problem is this solving?
resolves user being unable to remove or update the quantity of an item added offline

#### How should this be manually tested?
[workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
