### PR TITLE
Fix addToCart and removeFromCart events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pixel events of `addToCart` and `removeFromCart`.
+
 ## [2.23.0] - 2019-07-18
 
 ### Changed

--- a/react/__mocks__/orderForm.js
+++ b/react/__mocks__/orderForm.js
@@ -25,6 +25,12 @@ export default {
       detailUrl: '/pizza-pepperoni/p',
       skuName: 'Small',
       quantity: 2,
+      productRefId: 'PSMALL',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 14.9,
       listPrice: 14.9,
       parentItemIndex: null,
@@ -101,6 +107,12 @@ export default {
       detailUrl: '/classic-crust/p',
       skuName: 'Classic Crust',
       quantity: 1,
+      productRefId: 'CLASSICCRUST',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 0,
       listPrice: 0,
       parentItemIndex: 0,
@@ -121,6 +133,12 @@ export default {
       detailUrl: '/pepperoni/p',
       skuName: 'Pepperoni',
       quantity: 1,
+      productRefId: 'PEPPERONI',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 0,
       listPrice: 0,
       parentItemIndex: 0,
@@ -141,6 +159,12 @@ export default {
       detailUrl: '/ham/p',
       skuName: 'Ham',
       quantity: 3,
+      productRefId: 'HAM',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 1.5,
       listPrice: 1.5,
       parentItemIndex: 0,
@@ -161,6 +185,12 @@ export default {
       detailUrl: '/pineapple/p',
       skuName: 'Pineapple',
       quantity: 3,
+      productRefId: 'PINEAPPLE',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 1,
       listPrice: 1,
       parentItemIndex: 0,
@@ -464,6 +494,12 @@ export const fullItems = {
       detailUrl: '/pizza-pepperoni/p',
       skuName: 'Small',
       quantity: 1,
+      productRefId: 'PSMALL',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 14.9,
       listPrice: 14.9,
       parentItemIndex: null,
@@ -540,6 +576,12 @@ export const fullItems = {
       detailUrl: '/classic-crust/p',
       skuName: 'Classic Crust',
       quantity: 1,
+      productRefId: 'CLASSICCRUST',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 0,
       listPrice: 0,
       parentItemIndex: null,
@@ -560,6 +602,12 @@ export const fullItems = {
       detailUrl: '/pepperoni/p',
       skuName: 'Pepperoni',
       quantity: 1,
+      productRefId: 'PEPPERONI',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 0,
       listPrice: 0,
       parentItemIndex: null,
@@ -580,6 +628,12 @@ export const fullItems = {
       detailUrl: '/ham/p',
       skuName: 'Ham',
       quantity: 3,
+      productRefId: 'HAM',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 1.5,
       listPrice: 1.5,
       parentItemIndex: null,
@@ -600,6 +654,12 @@ export const fullItems = {
       detailUrl: '/pineapple/p',
       skuName: 'Pineapple',
       quantity: 3,
+      productRefId: 'PINEAPPLE',
+      additionalInfo: {
+        brandName: 'PizzaHut'
+      },
+      productCategoryIds: '/1/',
+      productCategories: { 1: 'Pizza' },
       sellingPrice: 1,
       listPrice: 1,
       parentItemIndex: null,

--- a/react/__mocks__/vtex.store-resources/Queries.js
+++ b/react/__mocks__/vtex.store-resources/Queries.js
@@ -16,6 +16,12 @@ export const orderForm = gql`
         name
         imageUrl
         detailUrl
+        productRefId
+        additionalInfo {
+          brandName
+        }
+        productCategoryIds
+        productCategories
         skuName
         quantity
         sellingPrice

--- a/react/utils/pixelHelper.ts
+++ b/react/utils/pixelHelper.ts
@@ -1,0 +1,78 @@
+export function mapCartItemToPixel(item: CartItem): PixelCartItem {
+  return {
+    skuId: item.id,
+    variant: item.skuName,
+    price: item.sellingPrice,
+    name: item.name,
+    quantity: item.quantity,
+    productRefId: item.productRefId,
+    brand: item.additionalInfo ? item.additionalInfo.brandName : '',
+    category: productCategory(item),
+  }
+}
+
+export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
+  // Change this `/Apparel & Accessories/Clothing/Tops/`
+  // to this `Apparel & Accessories/Clothing/Tops`
+  const category = item.category
+    ? item.category.slice(1).slice(0, -1)
+    : ''
+
+  return {
+    skuId: item.id,
+    variant: item.skuName,
+    price: item.sellingPrice,
+    name: item.name,
+    quantity: item.quantity,
+    productRefId: item.productRefId,
+    brand: item.brand,
+    category,
+  }
+}
+
+function productCategory(item: CartItem) {
+  try {
+    const categoryIds = item.productCategoryIds.split('/').filter(c => c.length)
+    const category = categoryIds.map(id => item.productCategories[id]).join('/')
+
+    return category
+  } catch {
+    return ''
+  }
+}
+
+interface PixelCartItem {
+  skuId: string
+  variant: string
+  price: number
+  name: string
+  quantity: number
+  productRefId: string
+  brand: string
+  category: string
+}
+
+interface BuyButtonItem {
+  id: string
+  skuName: string
+  sellingPrice: number
+  name: string
+  quantity: number
+  productRefId: string
+  brand: string
+  category: string
+}
+
+interface CartItem {
+  id: string
+  skuName: string
+  sellingPrice: number
+  name: string
+  quantity: number
+  productRefId: string
+  additionalInfo: {
+    brandName: string
+  }
+  productCategoryIds: string
+  productCategories: Record<string, string>
+}

--- a/react/utils/pixelHelper.ts
+++ b/react/utils/pixelHelper.ts
@@ -15,7 +15,7 @@ export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
   // Change this `/Apparel & Accessories/Clothing/Tops/`
   // to this `Apparel & Accessories/Clothing/Tops`
   const category = item.category
-    ? item.category.slice(1).slice(0, -1)
+    ? item.category.slice(1, -1)
     : ''
 
   return {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Properly trigger add and remove from cart event to pixels.

#### What problem is this solving?

`addToCart` and `removeFromCart` were being called with null values or wrong data.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com

#### Screenshots or example usage

Buy button from shelf works:
- Add and item from home shelf
- Remove item from minicart


Buy button from PDP works:
- Add item from Product page
- Remove item from minicart

Check `dataLayer` variable in Dev Tools, check the events addToCart and removeFromCart have all fields filled.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
