### PR TITLE
Prevent `addToCart` mutation from adding duplicate items to the Minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `addToCart` mutation would add items to the minicart even though they were already there.
+
 ## [2.24.2] - 2019-08-09
 ### Fixed
 - Removed overflow-hidden token inserted when only one item on minicart.

--- a/react/localState/index.js
+++ b/react/localState/index.js
@@ -50,9 +50,10 @@ export default function(client) {
         const data = cache.readQuery({ query: fullMinicartQuery })
 
         const cartItems = JSON.parse(data.minicart.items)
+        const newItems = items.filter(item => !cartItems.find(((cartItem) => cartItem.id === item.id)))
 
         const writeItems = cartItems.concat(
-          items.map(item => ({
+          newItems.map(item => ({
             ...item,
             localStatus: navigator.onLine
               ? ITEMS_STATUS.MODIFIED
@@ -71,6 +72,7 @@ export default function(client) {
             },
           },
         })
+
         return writeItems
       },
       updateItems: (_, { items: newItems }, { cache }) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent `addToCart` mutation from adding duplicate items to the Minicart.

#### What problem is this solving?

The `addToCart` mutation would always add the item being passed to it to the Apollo state even when that item was just a duplicate, that resulted in a few unnecessary rerenders and a bug where the `quantity` badge in the minicart would change to `quantity + 1` just to be changed back to `quantity` in a second.

#### How should this be manually tested?

[Workspace](https://victorhmp--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
