### PR TITLE
Add new CSS handles to Minicart components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New CSS handles to `MinicartFooter` component.
+- New CSS handles to all components.
 
 ## [2.26.1] - 2019-09-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New CSS handles to `MinicartFooter` component.
 
 ## [2.26.1] - 2019-09-20
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,17 @@ Below, we describe the namespaces that are defined in the minicart.
 | `contentDiscount` | The total discount on the minicart footer                    | [MinicartFooter](/react/components/MinicartFooter.js)   |
 | `contentPrice`    | Total price of the products on the minicart footer           | [MinicartFooter](/react/components/MinicartFooter.js)   |
 | `contentFooter`   | The minicart footer main container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `itemContainer`   | The container of a single item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
+| `itemDeleteIcon`   | The container of the delete item icon next to each item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
+| `itemDeleteIconLoader`   | The loading state for the delete item icon next to each item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
+| `popupContentContainer`   | The main container for content inside the popup variant of the minicart                           | [Popup](/react/components/Popup.js)   |
+| `popupChildrenContainer`   | The main container for children content inside the popup variant on the minicart                           | [Popup](/react/components/Popup.js)   |
+| `footerShippingPriceContainer`   | The shipping price main container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `footerShippingPriceLabelContainer`   | The shipping price label container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `footerShippingPriceLabelContainer`   | The shipping price label container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `sidebarRightCaretContainer`   | The caret icon container in the sidebar variant of the minicart                          | [Sidebar](/react/components/Sidebar.js)   |
+| `sidebarItemQuantityContainer`   | The item quantity container in the sidebar variant of the minicart                          | [Sidebar](/react/components/Sidebar.js)   |
+
 
 ## Troubleshooting
 

--- a/react/__tests__/__snapshots__/MiniCart.test.js.snap
+++ b/react/__tests__/__snapshots__/MiniCart.test.js.snap
@@ -41,22 +41,22 @@ exports[`<MiniCart /> should match the snapshot in popup mode 1`] = `
           style="right: -40px;"
         >
           <div
-            class="shadow-3"
+            class="popupContentContainer shadow-3"
           >
             <div
               class="arrowUp absolute top-0 shadow-3 bg-base h1 w1 pa4 rotate-45"
             />
             <div
-              class="mt3 bg-base relative flex flex-column"
+              class="popupChildrenContainer mt3 bg-base relative flex flex-column"
             >
               <div
                 class="content overflow-x-hidden pa1 contentSmall bg-base"
               >
                 <section
-                  class="relative flex"
+                  class="itemContainer relative flex"
                 >
                   <div
-                    class="fr absolute top-0 right-0"
+                    class="itemDeleteIcon fr absolute top-0 right-0"
                   >
                     <button
                       variation="tertiary"
@@ -165,7 +165,7 @@ exports[`<MiniCart /> should match the snapshot in sidebar mode 1`] = `
                 class="sidebarHeader pointer flex flex-row items-center pa5 h3 bg-base w-100 z-max bb b--muted-3 bw1"
               >
                 <div
-                  class="c-muted-1 pa4 flex items-center"
+                  class="sidebarRightCaretContainer c-muted-1 pa4 flex items-center"
                 >
                   <svg
                     class="undefined IconCaret"
@@ -179,7 +179,7 @@ exports[`<MiniCart /> should match the snapshot in sidebar mode 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="relative c-muted-1"
+                  class="sidebarItemQuantityContainer relative c-muted-1"
                 >
                   <svg
                     class="undefined IconCart"
@@ -202,10 +202,10 @@ exports[`<MiniCart /> should match the snapshot in sidebar mode 1`] = `
                 class="content overflow-x-hidden pa1 contentLarge"
               >
                 <section
-                  class="relative flex"
+                  class="itemContainer relative flex"
                 >
                   <div
-                    class="fr absolute top-0 right-0"
+                    class="itemDeleteIcon fr absolute top-0 right-0"
                   >
                     <button
                       variation="tertiary"

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -187,10 +187,12 @@ class MiniCartContent extends Component {
         <div className={classes}>
           {itemsToShow.map((item, index) => (
             <Fragment key={item.id}>
-              <section className="relative flex">
-                <div className="fr absolute top-0 right-0">
+              <section className={`${styles.itemContainer} relative flex`}>
+                <div
+                  className={`${styles.itemDeleteIcon} fr absolute top-0 right-0`}
+                >
                   {isUpdating[item.id] ? (
-                    <div className="ma4">
+                    <div className={`${styles.itemDeleteIconLoader} ma4`}>
                       <Spinner size={18} />
                     </div>
                   ) : (
@@ -309,5 +311,5 @@ export default compose(
   injectIntl,
   withUpdateItemsMutation,
   withUpdateLocalItemsMutation,
-  withPixel,
+  withPixel
 )(MiniCartContent)

--- a/react/components/MiniCartFooter.js
+++ b/react/components/MiniCartFooter.js
@@ -39,9 +39,7 @@ const MiniCartFooter = ({
   const shouldShowShippingCost = showShippingCost && shippingCost > 0
 
   const footerClasses = classNames(
-    `${
-      minicart.contentFooter
-    } w-100 bg-base pa4 pv5 flex flex-column items-end`,
+    `${minicart.contentFooter} w-100 bg-base pa4 pv5 flex flex-column items-end`,
     {
       'bt b--muted-3': shouldShowShippingCost || isSizeLarge,
     }
@@ -50,8 +48,12 @@ const MiniCartFooter = ({
   return (
     <Fragment>
       {shouldShowShippingCost && (
-        <div className="flex items-center justify-between ma5">
-          <div className="t-body c-muted-1">
+        <div
+          className={`${minicart.footerShippingPriceContainer} flex items-center justify-between ma5`}
+        >
+          <div
+            className={`${minicart.footerShippingPriceLabelContainer} t-body c-muted-1`}
+          >
             <FormattedMessage id="store/minicart.shipping-cost" />
           </div>
           <ProductPrice

--- a/react/components/Popup.js
+++ b/react/components/Popup.js
@@ -22,11 +22,13 @@ const Popup = ({ children, onOutsideClick }) => {
         className={`${minicart.box} dn db-ns absolute z-max flex flex-colunm`}
         style={boxPositionStyle}
       >
-        <div className="shadow-3">
+        <div className={`${minicart.popupContentContainer} shadow-3`}>
           <div
             className={`${minicart.arrowUp} absolute top-0 shadow-3 bg-base h1 w1 pa4 rotate-45`}
           />
-          <div className="mt3 bg-base relative flex flex-column">
+          <div
+            className={`${minicart.popupChildrenContainer} mt3 bg-base relative flex flex-column`}
+          >
             {children}
           </div>
         </div>

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -65,12 +65,14 @@ class Sidebar extends Component {
               className={`${minicart.sidebarHeader} pointer flex flex-row items-center pa5 h3 bg-base w-100 z-max bb b--muted-3 bw1`}
             >
               <div
-                className="c-muted-1 pa4 flex items-center"
+                className={`${minicart.sidebarRightCaretContainer} c-muted-1 pa4 flex items-center`}
                 onClick={onOutsideClick}
               >
                 <IconCaret orientation="right" size={17} />
               </div>
-              <div className="relative c-muted-1">
+              <div
+                className={`${minicart.sidebarItemQuantityContainer} relative c-muted-1`}
+              >
                 <IconCart size={iconSize} />
                 {quantity > 0 && (
                   <span

--- a/react/minicart.css
+++ b/react/minicart.css
@@ -1,17 +1,31 @@
-.container {}
-.label {}
-.itemImage {}
-.item {}
-.content {}
-.contentDiscount {}
-.contentPrice {}
-.itemName {}
-.itemNameLarge {}
-.itemFooter {}
-.imgContainer {}
-.itemRemoveBtn {}
-.sidebarScrim {}
-.sidebarHeader {}
+.container {
+}
+.label {
+}
+.itemImage {
+}
+.item {
+}
+.content {
+}
+.contentDiscount {
+}
+.contentPrice {
+}
+.itemName {
+}
+.itemNameLarge {
+}
+.itemFooter {
+}
+.imgContainer {
+}
+.itemRemoveBtn {
+}
+.sidebarScrim {
+}
+.sidebarHeader {
+}
 
 .contentSmall {
   max-height: 383px;
@@ -40,9 +54,17 @@
   height: 100%;
 }
 
-.contentFooter { }
+.contentFooter {
+}
 
-.footerSpacer { }
+.footerSpacer {
+}
+
+.footerShippingPriceContainer {
+}
+
+.footerShippingPriceLabelContainer {
+}
 
 @media only screen and (max-width: 40rem) {
   body.sidebarOpen {

--- a/react/minicart.css
+++ b/react/minicart.css
@@ -6,6 +6,14 @@
 }
 .item {
 }
+.itemContainer {
+}
+.itemDeleteIcon {
+}
+.itemDeleteIcon {
+}
+.itemDeleteIconLoader {
+}
 .content {
 }
 .contentDiscount {
@@ -64,6 +72,18 @@
 }
 
 .footerShippingPriceLabelContainer {
+}
+
+.popupContentContainer {
+}
+
+.popupChildrenContainer {
+}
+
+.sidebarRightCaretContainer {
+}
+
+.sidebarItemQuantityContainer {
 }
 
 @media only screen and (max-width: 40rem) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new CSS handles to all components rendered by `vtex.minicart`.

This should close this issue: https://github.com/vtex-apps/store-discussion/issues/125

#### What problem is this solving?

Enables our user to further customize their minicarts.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
