### PR TITLE
Add missing data to fulfill pixel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add missing data necessary to pixel events.
 
 ## [2.27.1] - 2019-10-14
 ### Fixed

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -119,27 +119,45 @@ class MiniCartContent extends Component {
       ? orderForm.value
       : this.sumItemsPrice(orderForm.items)
 
-  createProductShapeFromItem = item => ({
-    productName: item.name,
-    linkText: item.detailUrl.replace(/^\//, '').replace(/\/p$/, ''),
-    sku: {
-      seller: {
-        commertialOffer: {
-          Price: item.sellingPriceWithAssemblies * item.quantity,
-          ListPrice: item.listPrice,
+
+  getItemCategory = (item) => {
+    if (!item.productCategoryIds || !item.productCategories) {
+      return ''
+    }
+
+    return item.productCategoryIds
+      .split('/')
+      .reduce((acc, id) => acc.concat(item.productCategories[id]), [])
+      .join('/')
+      .slice(1, -1)
+  }
+
+  createProductShapeFromItem = item => {
+    return ({
+      productName: item.name,
+      brand: item.additionalInfo ? item.additionalInfo.brandName : undefined,
+      category: this.getItemCategory(item),
+      productRefId: item.productRefId,
+      linkText: item.detailUrl.replace(/^\//, '').replace(/\/p$/, ''),
+      sku: {
+        seller: {
+          commertialOffer: {
+            Price: item.sellingPriceWithAssemblies * item.quantity,
+            ListPrice: item.listPrice,
+          },
+          sellerId: item.seller,
         },
-        sellerId: item.seller,
+        name: item.skuName,
+        itemId: item.id,
+        image: {
+          imageUrl: changeImageUrlSize(toHttps(item ? item.imageUrl : ''), 240),
+        },
       },
-      name: item.skuName,
-      itemId: item.id,
-      image: {
-        imageUrl: changeImageUrlSize(toHttps(item ? item.imageUrl : ''), 240),
-      },
-    },
-    assemblyOptions: item.assemblyOptions,
-    quantity: item.quantity,
-    cartIndex: item.cartIndex,
-  })
+      assemblyOptions: item.assemblyOptions,
+      quantity: item.quantity,
+      cartIndex: item.cartIndex,
+    })
+  }
 
   get isUpdating() {
     const { isUpdating } = this.state


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add some missing data fields that it's being used by Product Summary components to trigger pixel events.

#### How should this be manually tested?

1. Open https://breno--storecomponents.myvtex.com/tank-top/p
2. Add something to cart
3. Change an item quantity in minicart
4. Check the last addToCart event in `dataLayer` and see that it has all the properties

Related PR to this fix: https://github.com/vtex-apps/product-summary/pull/200

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
