### PR TITLE
Add items to cart validating with id and seller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- New items that must be added in the local state are filtered using "id" and "seller".
 
 ## [2.28.0] - 2019-11-11
 ### Added

--- a/react/localState/index.js
+++ b/react/localState/index.js
@@ -50,7 +50,9 @@ export default function(client) {
         const data = cache.readQuery({ query: fullMinicartQuery })
 
         const cartItems = JSON.parse(data.minicart.items)
-        const newItems = items.filter(item => !cartItems.find(((cartItem) => cartItem.id === item.id)))
+        const newItems = items.filter(
+          item => !cartItems.find(cartItem => cartItem.id === item.id && cartItem.seller === item.seller)
+        )
 
         const writeItems = cartItems.concat(
           newItems.map(item => ({


### PR DESCRIPTION
#### What is the purpose of this pull request?
Currently we working a functionality that allows the user to see the "additional offers" of the same product, in other words means to see all the offers of the different sellers associated with a product, with this possibility the user can add the same product to the cart but sold by a different "seller". We try to perform this functionality using the BuyButton of the store-component, but when you try to add the product with another seller the buy button notice that the product is already added to the cart.

#### What problem is this solving?
We note that the BuyButton uses the “addToCart” mutation (minicart\react\localState\index.js) to add to the cart, here you will find the new items that must be added in the local state should not have been added recently, such validation is performed using the "id" of the item, which is insufficient and does not allow adding that item with different vendors. The change that was made was to validate the new items using the "id" and the "seller"

#### Screenshots or example usage
![screencapture-chrome-extension-fdpohaocaechififmbbbbbknoalclacl-editor-html-2019-11-01-14_08_56](https://user-images.githubusercontent.com/46934781/68049588-4d6e5c80-fcb1-11e9-97d0-14be342fc9c8.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
