### PR TITLE
Add new iconsProps prop to Minicart component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `iconsProps` prop.
 
 ## [2.28.1] - 2019-11-13
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 # VTEX Minicart
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 
 ## Description
@@ -82,20 +83,21 @@ The minicart has as a required block the `product-summary`. So, any minicart blo
 
 Through the Storefront, you can change the minicart's behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                   | Type      | Description                                          | Default value        |
-| --------------------------- | --------- | ---------------------------------------------------- | -------------------- |
-| `type`                      | `Enum`    | Define Minicart mode. (values: 'popup' or 'sidebar') | popup                |
-| `showDiscount`              | `Boolean` | Shows the total discount of your cart                | false                 |
-| `labelMiniCartEmpty`        | `String`  | Text that is displayed when the cart is empty        | `Your cart is empty` |
-| `linkButtonFinishShopping` | `String`  | Link to redirect after clicking in the finishe shopping button         | `/checkout/#/cart`     |
-| `labelButtonFinishShopping` | `String`  | Text displayed in the finish shopping button         | `Go to checkout`     |
-| `iconClasses`                   | `String`      | The minicart's icon classes                                         | `''`         |
-| `iconLabel`                |   `String`    | The minicart's icon label                                        |  undefined       | 
-| `labelClasses`                   | `String`      | The minicart's label classes                                          | `gray`        |
-| `hideContent`                   | `Boolean`      |      If the minicart should not show its contents once its icon is clicked                                     | false       |
-| `showShippingCost`                   | `Boolean`     | If the shipping cost show be displayed on cart                                          | false        |
-| `showTotalItemsQty`                   | `Boolean`      | If the cart should show the total quantity of items or just the quantity of different items in the cart                                          | false       |
-| `showPrice`                   | `Boolean`      | If the total price of the items in the cart should be displayed at its side                                          | false       |
+| Prop name                   | Type                                    | Description                                                                                             | Default value        |
+| --------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------- |
+| `type`                      | `Enum`                                  | Define Minicart mode. (values: 'popup' or 'sidebar')                                                    | popup                |
+| `showDiscount`              | `Boolean`                               | Shows the total discount of your cart                                                                   | false                |
+| `labelMiniCartEmpty`        | `String`                                | Text that is displayed when the cart is empty                                                           | `Your cart is empty` |
+| `linkButtonFinishShopping`  | `String`                                | Link to redirect after clicking in the finishe shopping button                                          | `/checkout/#/cart`   |
+| `labelButtonFinishShopping` | `String`                                | Text displayed in the finish shopping button                                                            | `Go to checkout`     |
+| `iconClasses`               | `String`                                | The minicart's icon classes                                                                             | `''`                 |
+| `iconLabel`                 | `String`                                | The minicart's icon label                                                                               | undefined            |
+| `labelClasses`              | `String`                                | The minicart's label classes                                                                            | `gray`               |
+| `hideContent`               | `Boolean`                               | If the minicart should not show its contents once its icon is clicked                                   | false                |
+| `showShippingCost`          | `Boolean`                               | If the shipping cost show be displayed on cart                                                          | false                |
+| `showTotalItemsQty`         | `Boolean`                               | If the cart should show the total quantity of items or just the quantity of different items in the cart | false                |
+| `showPrice`                 | `Boolean`                               | If the total price of the items in the cart should be displayed at its side                             | false                |
+| `iconsProps`                | `{ "viewBox": String, "size": Number }` | Props to be passed down to the icons from `store-icons`.                                                | -                    |
 
 Also, you can configure the product summary that is defined on minicart. See [here](https://github.com/vtex-apps/product-summary/blob/master/README.md#configuration) the Product Summary API.
 
@@ -127,33 +129,32 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 
 Below, we describe the namespaces that are defined in the minicart.
 
-| Class name        | Description                                                  | Component Source                                        |
-| ----------------- | ------------------------------------------------------------ | ------------------------------------------------------- |
-| `container`       | The main container of minicart                               | [index](/react/index.js)                                |
-| `label`           | Minicart icon label                                          | [index](/react/index.js)                                |
-| `badge`           | Minicart badge with the product quantity on it               | [index](/react/index.js)                                |
-| `arrowUp`         | Popup box arrow                                              | [Popup](/react/components/Popup.js)                     |
-| `box`             | The main container of the popup                              | [Popup](/react/components/Popup.js)                     |
-| `sidebarHeader`   | Minicart sidebar header container                            | [Sidebar](/react/components/Sidebar.js)                 |
-| `sidebar`         | Minicart sidebar main container                              | [Sidebar](/react/components/Sidebar.js)                 |
-| `sidebarOpen`     | Active when the sidebar is opened                            | [Sidebar](/react/components/Sidebar.js)                 |
-| `content`         | The container for the Minicart contents                      | [MinicartContent](/react/components/MinicartContent.js) |
-| `contentSmall`    | The container for the minicart contents when on desktop size | [MinicartContent](/react/components/MinicartContent.js) |
-| `contentLarge`    | The container for the minicart contents when on mobile size  | [MinicartContent](/react/components/MinicartContent.js) |
-| `contentDiscount` | The total discount on the minicart footer                    | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `contentPrice`    | Total price of the products on the minicart footer           | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `contentFooter`   | The minicart footer main container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `itemContainer`   | The container of a single item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
-| `itemDeleteIcon`   | The container of the delete item icon next to each item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
-| `itemDeleteIconLoader`   | The loading state for the delete item icon next to each item in the minicart                           | [MinicartContent](/react/components/MinicartContent.js)   |
-| `popupContentContainer`   | The main container for content inside the popup variant of the minicart                           | [Popup](/react/components/Popup.js)   |
-| `popupChildrenContainer`   | The main container for children content inside the popup variant on the minicart                           | [Popup](/react/components/Popup.js)   |
-| `footerShippingPriceContainer`   | The shipping price main container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `footerShippingPriceLabelContainer`   | The shipping price label container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `footerShippingPriceLabelContainer`   | The shipping price label container                           | [MinicartFooter](/react/components/MinicartFooter.js)   |
-| `sidebarRightCaretContainer`   | The caret icon container in the sidebar variant of the minicart                          | [Sidebar](/react/components/Sidebar.js)   |
-| `sidebarItemQuantityContainer`   | The item quantity container in the sidebar variant of the minicart                          | [Sidebar](/react/components/Sidebar.js)   |
-
+| Class name                          | Description                                                                      | Component Source                                        |
+| ----------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `container`                         | The main container of minicart                                                   | [index](/react/index.js)                                |
+| `label`                             | Minicart icon label                                                              | [index](/react/index.js)                                |
+| `badge`                             | Minicart badge with the product quantity on it                                   | [index](/react/index.js)                                |
+| `arrowUp`                           | Popup box arrow                                                                  | [Popup](/react/components/Popup.js)                     |
+| `box`                               | The main container of the popup                                                  | [Popup](/react/components/Popup.js)                     |
+| `sidebarHeader`                     | Minicart sidebar header container                                                | [Sidebar](/react/components/Sidebar.js)                 |
+| `sidebar`                           | Minicart sidebar main container                                                  | [Sidebar](/react/components/Sidebar.js)                 |
+| `sidebarOpen`                       | Active when the sidebar is opened                                                | [Sidebar](/react/components/Sidebar.js)                 |
+| `content`                           | The container for the Minicart contents                                          | [MinicartContent](/react/components/MinicartContent.js) |
+| `contentSmall`                      | The container for the minicart contents when on desktop size                     | [MinicartContent](/react/components/MinicartContent.js) |
+| `contentLarge`                      | The container for the minicart contents when on mobile size                      | [MinicartContent](/react/components/MinicartContent.js) |
+| `contentDiscount`                   | The total discount on the minicart footer                                        | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `contentPrice`                      | Total price of the products on the minicart footer                               | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `contentFooter`                     | The minicart footer main container                                               | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `itemContainer`                     | The container of a single item in the minicart                                   | [MinicartContent](/react/components/MinicartContent.js) |
+| `itemDeleteIcon`                    | The container of the delete item icon next to each item in the minicart          | [MinicartContent](/react/components/MinicartContent.js) |
+| `itemDeleteIconLoader`              | The loading state for the delete item icon next to each item in the minicart     | [MinicartContent](/react/components/MinicartContent.js) |
+| `popupContentContainer`             | The main container for content inside the popup variant of the minicart          | [Popup](/react/components/Popup.js)                     |
+| `popupChildrenContainer`            | The main container for children content inside the popup variant on the minicart | [Popup](/react/components/Popup.js)                     |
+| `footerShippingPriceContainer`      | The shipping price main container                                                | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `footerShippingPriceLabelContainer` | The shipping price label container                                               | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `footerShippingPriceLabelContainer` | The shipping price label container                                               | [MinicartFooter](/react/components/MinicartFooter.js)   |
+| `sidebarRightCaretContainer`        | The caret icon container in the sidebar variant of the minicart                  | [Sidebar](/react/components/Sidebar.js)                 |
+| `sidebarItemQuantityContainer`      | The item quantity container in the sidebar variant of the minicart               | [Sidebar](/react/components/Sidebar.js)                 |
 
 ## Troubleshooting
 
@@ -161,7 +162,7 @@ You can check if others are passing through similar issues [here](https://github
 
 ## Contributing
 
-Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project. 
+Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project.
 
 ## Tests
 

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -48,6 +48,11 @@ class MiniCartContent extends Component {
     itemsToShow: PropTypes.arrayOf(PropTypes.object),
     /* Pixel push */
     push: PropTypes.func.isRequired,
+    /** Props to passed to icons from store-icons */
+    iconsProps: PropTypes.shape({
+      viewBox: PropTypes.string,
+      size: PropTypes.number,
+    }),
   }
 
   state = { isUpdating: [] }
@@ -119,8 +124,7 @@ class MiniCartContent extends Component {
       ? orderForm.value
       : this.sumItemsPrice(orderForm.items)
 
-
-  getItemCategory = (item) => {
+  getItemCategory = item => {
     if (!item.productCategoryIds || !item.productCategories) {
       return ''
     }
@@ -133,7 +137,7 @@ class MiniCartContent extends Component {
   }
 
   createProductShapeFromItem = item => {
-    return ({
+    return {
       productName: item.name,
       brand: item.additionalInfo ? item.additionalInfo.brandName : undefined,
       category: this.getItemCategory(item),
@@ -156,7 +160,7 @@ class MiniCartContent extends Component {
       assemblyOptions: item.assemblyOptions,
       quantity: item.quantity,
       cartIndex: item.cartIndex,
-    })
+    }
   }
 
   get isUpdating() {
@@ -189,7 +193,8 @@ class MiniCartContent extends Component {
     onClickAction,
     isUpdating,
     isSizeLarge,
-    showShippingCost
+    showShippingCost,
+    iconsProps
   ) => {
     const MIN_ITEMS_TO_SCROLL = 2
 
@@ -214,7 +219,14 @@ class MiniCartContent extends Component {
                       <Spinner size={18} />
                     </div>
                   ) : (
-                    <ButtonWithIcon icon={<IconDelete size={15} activeClassName="c-muted-2" />}
+                    <ButtonWithIcon
+                      icon={
+                        <IconDelete
+                          {...iconsProps}
+                          size={15}
+                          activeClassName="c-muted-2"
+                        />
+                      }
                       variation="tertiary"
                       onClick={() => this.handleItemRemoval(item, index)}
                     />

--- a/react/components/MiniCartContent.js
+++ b/react/components/MiniCartContent.js
@@ -222,9 +222,9 @@ class MiniCartContent extends Component {
                     <ButtonWithIcon
                       icon={
                         <IconDelete
-                          {...iconsProps}
                           size={15}
                           activeClassName="c-muted-2"
+                          {...iconsProps}
                         />
                       }
                       variation="tertiary"
@@ -286,6 +286,7 @@ class MiniCartContent extends Component {
       showShippingCost,
       orderForm,
       loading,
+      iconsProps,
     } = this.props
     const { isUpdating } = this.state
 
@@ -315,7 +316,8 @@ class MiniCartContent extends Component {
       onClickAction,
       isUpdating,
       isSizeLarge,
-      showShippingCost
+      showShippingCost,
+      iconsProps
     )
   }
 }

--- a/react/components/Sidebar.js
+++ b/react/components/Sidebar.js
@@ -34,7 +34,14 @@ class Sidebar extends Component {
   }
 
   render() {
-    const { isOpen, onOutsideClick, intl, iconSize, quantity } = this.props
+    const {
+      isOpen,
+      onOutsideClick,
+      intl,
+      iconSize,
+      quantity,
+      iconsProps,
+    } = this.props
 
     if (typeof document === 'undefined') {
       return null
@@ -68,12 +75,12 @@ class Sidebar extends Component {
                 className={`${minicart.sidebarRightCaretContainer} c-muted-1 pa4 flex items-center`}
                 onClick={onOutsideClick}
               >
-                <IconCaret orientation="right" size={17} />
+                <IconCaret orientation="right" size={17} {...iconsProps} />
               </div>
               <div
                 className={`${minicart.sidebarItemQuantityContainer} relative c-muted-1`}
               >
-                <IconCart size={iconSize} />
+                <IconCart size={iconSize} {...iconsProps} />
                 {quantity > 0 && (
                   <span
                     className={`${minicart.badge} c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
@@ -111,6 +118,11 @@ Sidebar.propTypes = {
   quantity: PropTypes.number.isRequired,
   /* Cart icon size */
   iconSize: PropTypes.number,
+  /** Props to passed to icons from store-icons */
+  iconsProps: PropTypes.shape({
+    viewBox: PropTypes.string,
+    size: PropTypes.number,
+  }),
 }
 
 export default injectIntl(Sidebar)

--- a/react/index.js
+++ b/react/index.js
@@ -1,13 +1,5 @@
 import classNames from 'classnames'
-import {
-  map,
-  partition,
-  path,
-  pathOr,
-  pick,
-  isNil,
-  prop,
-} from 'ramda'
+import { map, partition, path, pathOr, pick, isNil, prop } from 'ramda'
 import React, {
   useState,
   useEffect,
@@ -109,8 +101,12 @@ const useUpdateOrderFormOnState = (data, minicartState, updateOrderForm) => {
         const remoteOrderForm = data.orderForm
 
         if (remoteOrderForm || !orderFormData) {
-          const forceRemoteOrderform = !hasSavedRemoteOrderFormRef.current && remoteOrderForm
-          if (forceRemoteOrderform || (!path(['orderForm'], minicartState) && remoteOrderForm)) {
+          const forceRemoteOrderform =
+            !hasSavedRemoteOrderFormRef.current && remoteOrderForm
+          if (
+            forceRemoteOrderform ||
+            (!path(['orderForm'], minicartState) && remoteOrderForm)
+          ) {
             hasSavedRemoteOrderFormRef.current = true
             await updateOrderForm(remoteOrderForm)
           }
@@ -162,6 +158,7 @@ const MiniCart = ({
   updateItemsMutation,
   addToCartMutation,
   updateLocalItemStatus,
+  iconsProps,
 }) => {
   useLinkState(client)
 
@@ -289,7 +286,7 @@ const MiniCart = ({
           if (itemsToAdd.length > 0) {
             push({
               event: 'addToCart',
-              items: itemsToAdd.map(mapBuyButtonItemToPixel)
+              items: itemsToAdd.map(mapBuyButtonItemToPixel),
             })
           }
 
@@ -337,7 +334,15 @@ const MiniCart = ({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [intl, isOffline, showToast, addItems, mutateUpdateItems, modifiedItems, push]
+    [
+      intl,
+      isOffline,
+      showToast,
+      addItems,
+      mutateUpdateItems,
+      modifiedItems,
+      push,
+    ]
   )
 
   const handleClickButton = event => {
@@ -393,9 +398,10 @@ const MiniCart = ({
       onClickAction={handleUpdateContentVisibility}
       showShippingCost={showShippingCost}
       updatingOrderForm={isUpdatingOrderForm}
+      iconsProps={iconsProps}
     />
   )
-  
+
   const priceClasses = classNames(
     `${styles.label} dn-m db-l t-action--small ${labelClasses}`,
     {
@@ -406,7 +412,9 @@ const MiniCart = ({
 
   const isPriceVisible = showPrice && orderForm && orderForm.value > 0
   const iconLabelClasses = classNames(
-    `${styles.label} dn-m db-l ${ isPriceVisible ? 't-mini' : 't-action--small'} ${labelClasses}`,
+    `${styles.label} dn-m db-l ${
+      isPriceVisible ? 't-mini' : 't-action--small'
+    } ${labelClasses}`,
     {
       pl6: quantity > 0,
       pl4: quantity <= 0,
@@ -419,7 +427,7 @@ const MiniCart = ({
         <ButtonWithIcon
           icon={
             <span className={`relative ${iconClasses}`}>
-              <IconCart size={iconSize} />
+              <IconCart {...iconsProps} size={iconSize} />
               {quantity > 0 && (
                 <span
                   data-testid="item-qty"
@@ -431,22 +439,26 @@ const MiniCart = ({
             </span>
           }
           variation="tertiary"
-          onClick={handleClickButton}>
+          onClick={handleClickButton}
+        >
           {(iconLabel || isPriceVisible) && (
             <span className="flex items-center">
-                <span className="flex flex-column items-start">
-                  {iconLabel && <span className={iconLabelClasses}>{iconLabel}</span>}
-                  {isPriceVisible && (
-                    <span data-testid="total-price" className={priceClasses}>
-                      <div>
-                        <ProductPrice 
-                        showLabels={false} 
-                        showListPrice={false} 
-                        sellingPrice={orderForm.value} />
-                      </div>
-                    </span>
-                  )}
-                </span>
+              <span className="flex flex-column items-start">
+                {iconLabel && (
+                  <span className={iconLabelClasses}>{iconLabel}</span>
+                )}
+                {isPriceVisible && (
+                  <span data-testid="total-price" className={priceClasses}>
+                    <div>
+                      <ProductPrice
+                        showLabels={false}
+                        showListPrice={false}
+                        sellingPrice={orderForm.value}
+                      />
+                    </div>
+                  </span>
+                )}
+              </span>
             </span>
           )}
         </ButtonWithIcon>
@@ -457,6 +469,7 @@ const MiniCart = ({
               iconSize={iconSize}
               onOutsideClick={handleUpdateContentVisibility}
               isOpen={isOpen}
+              iconsProps={iconsProps}
             >
               {miniCartContent}
             </Sidebar>

--- a/react/index.js
+++ b/react/index.js
@@ -427,7 +427,7 @@ const MiniCart = ({
         <ButtonWithIcon
           icon={
             <span className={`relative ${iconClasses}`}>
-              <IconCart {...iconsProps} size={iconSize} />
+              <IconCart size={iconSize} {...iconsProps} />
               {quantity > 0 && (
                 <span
                   data-testid="item-qty"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new `iconsProps` prop.

#### What problem is this solving?

This should enable the user to have greater control over the profile icon from store-icons being used by the `minicart` app.

#### How should this be manually tested?

See how weird the icons from Minicart look:
[Workspace](https://storeicons--storecomponents.myvtex.com/)

This was achieved with:

```json
"minicart": {
    "props": {
      "iconsProps": {
        "viewBox": "0, 0, 32, 32",
        "size": 90
      }
    }
  },
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
