### PR TITLE
Set proper cart URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Link to Cart now varies depending on the version of `vtex.checkout` installed in the account.
 
 ## [2.31.1] - 2019-12-05
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ Through the Storefront, you can change the minicart's behavior and interface. Ho
 | `type`                      | `Enum`                                  | Define Minicart mode. (values: 'popup' or 'sidebar')                                                    | popup                |
 | `showDiscount`              | `Boolean`                               | Shows the total discount of your cart                                                                   | false                |
 | `labelMiniCartEmpty`        | `String`                                | Text that is displayed when the cart is empty                                                           | `Your cart is empty` |
-| `linkButtonFinishShopping`  | `String`                                | Link to redirect after clicking in the finishe shopping button                                          | `/checkout/#/cart`   |
+| `linkButtonFinishShopping`  | `String`                                | Link to redirect after clicking on the finished shopping button                                         | undefined            |
 | `labelButtonFinishShopping` | `String`                                | Text displayed in the finish shopping button                                                            | `Go to checkout`     |
 | `iconClasses`               | `String`                                | The minicart's icon classes                                                                             | `''`                 |
 | `iconLabel`                 | `String`                                | The minicart's icon label                                                                               | undefined            |

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,8 @@
     "vtex.product-list": "0.x",
     "vtex.device-detector": "0.x",
     "vtex.store-drawer": "0.x",
-    "vtex.checkout-summary": "0.x"
+    "vtex.checkout-summary": "0.x",
+    "vtex.checkout-resources": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 import { useCssHandles } from 'vtex.css-handles'
 import { Button } from 'vtex.styleguide'
 
@@ -25,6 +26,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
+  const { url: checkoutUrl } = useCheckoutURL()
 
   const minicartContentClasses = `${handles.minicartContent} ${
     variation === 'drawer' ? styles.drawerStyles : styles.popupStyles
@@ -54,7 +56,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
         <ExtensionPoint id="minicart-summary" />
         <Button
           id="proceed-to-checkout"
-          href={finishShoppingButtonLink}
+          href={finishShoppingButtonLink || checkoutUrl}
           variation="primary"
           block
         >

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useCssHandles } from 'vtex.css-handles'
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 
 import MinicartIconButton from './components/MinicartIconButton'
 import DrawerMode from './components/DrawerMode'
@@ -13,12 +14,13 @@ const CSS_HANDLES = ['minicartWrapperContainer', 'minicartContainer'] as const
 const Minicart: FC<MinicartProps> = ({
   maxDrawerWidth = 400,
   drawerSlideDirection = 'rightToLeft',
-  linkVariationUrl = '/checkout/#/cart',
+  linkVariationUrl,
   children,
 }) => {
   const { orderForm }: OrderFormContext = useOrderForm()
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
+  const { url: checkoutUrl } = useCheckoutURL()
 
   if (!orderForm) {
     return null
@@ -30,7 +32,7 @@ const Minicart: FC<MinicartProps> = ({
         className={`${handles.minicartWrapperContainer} relative fr flex items-center`}
       >
         <div className={`${handles.minicartContainer} flex flex-column`}>
-          <a href={linkVariationUrl}>{MinicartIconButton}</a>
+          <a href={linkVariationUrl || checkoutUrl}>{MinicartIconButton}</a>
         </div>
       </aside>
     )

--- a/react/index.js
+++ b/react/index.js
@@ -17,6 +17,7 @@ import { orderForm as orderFormQuery } from 'vtex.store-resources/Queries'
 import { addToCart, updateItems } from 'vtex.store-resources/Mutations'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 import ProductPrice from 'vtex.store-components/ProductPrice'
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 
 import MiniCartContent from './legacy/components/MiniCartContent'
 import Sidebar from './legacy/components/Sidebar'
@@ -123,13 +124,7 @@ const useUpdateOrderFormOnState = (data, minicartState, updateOrderForm) => {
 }
 
 const partitionItemsAddUpdate = clientItems => {
-  return partition(
-    compose(
-      isNil,
-      prop('cartIndex')
-    ),
-    clientItems
-  )
+  return partition(compose(isNil, prop('cartIndex')), clientItems)
 }
 
 /**
@@ -240,6 +235,8 @@ const MiniCart = ({
   const { push } = usePixel()
 
   const orderFormRef = useRef(orderForm)
+
+  const { url: checkoutUrl } = useCheckoutURL()
 
   useEffect(() => {
     orderFormRef.current = orderForm
@@ -393,7 +390,7 @@ const MiniCart = ({
       loading={data.loading}
       showDiscount={showDiscount}
       labelMiniCartEmpty={labelMiniCartEmpty}
-      linkButton={linkButtonFinishShopping}
+      linkButton={linkButtonFinishShopping || checkoutUrl}
       labelButton={labelButtonFinishShopping}
       onClickProduct={handleClickProduct}
       onClickAction={handleUpdateContentVisibility}
@@ -576,7 +573,6 @@ EnhancedMinicart.schema = {
     },
     linkButtonFinishShopping: {
       title: 'admin/editor.minicart.linkButtonFinishShopping.title',
-      default: '/checkout/#/cart',
       type: 'string',
       isLayout: false,
     },

--- a/react/legacy/__mocks__/vtex.checkout-resources/Utils.js
+++ b/react/legacy/__mocks__/vtex.checkout-resources/Utils.js
@@ -1,0 +1,1 @@
+export const useCheckoutURL = () => ({ url: '/checkout/#/cart' })

--- a/react/legacy/components/MiniCartFooter.js
+++ b/react/legacy/components/MiniCartFooter.js
@@ -22,8 +22,7 @@ const MiniCartFooter = ({
   showShippingCost,
 }) => {
   const { rootPath = '' } = useRuntime()
-  const handleClickButton = () =>
-    location.assign(rootPath + (buttonLink || '/checkout/#/cart'))
+  const handleClickButton = () => location.assign(rootPath + buttonLink)
 
   const priceAndDiscountClasses = classNames(
     `${minicart.contentDiscount} w-100 flex justify-end items-center mb3`,

--- a/react/package.json
+++ b/react/package.json
@@ -15,9 +15,9 @@
     "eslint": "^6.0.1",
     "eslint-config-vtex-react": "^5.0.0",
     "eslint-plugin-import": "2.16.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "prop-types": "^15.7.2",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "dependencies": {
     "apollo-client": "^2.5.1",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4252,10 +4252,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.0.0:
   version "24.0.0"
@@ -5228,10 +5228,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.3.3333"

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -4,10 +4,7 @@
     "children": ["minicart-base-content"]
   },
   "minicart-base-content": {
-    "blocks": ["minicart-product-list", "minicart-summary"],
-    "props": {
-      "finishShoppingButtonLink": "/checkout/#/cart"
-    }
+    "blocks": ["minicart-product-list", "minicart-summary"]
   },
   "minicart-product-list": {
     "blocks": ["product-list"]


### PR DESCRIPTION
#### What is the purpose of this pull request?
This makes the Minicart send the user to the appropriate Cart, depending on the version of `vtex.checkout` installed in the account, using the `useCheckoutURL` hook from `vtex.checkout-resources`. This change was implemented in both the legacy Minicart and the new Minicart that uses the Checkout components.

#### What problem is this solving?
We're making a new Checkout in IO, and the new Cart has a different URL than the current one. We want to direct the user to the correct one depending on whether the account has the new Cart enabled or not.

#### How should this be manually tested?
Use these four workspaces: 
[Current Minicart, current Checkout](https://oldv0--checkoutio.myvtex.com/cart)
[Current Minicart, new Checkout](https://oldv1--checkoutio.myvtex.com/cart)
[New Minicart, current Checkout](https://newv0--checkoutio.myvtex.com/cart)
[New Minicart, new Checkout](https://newv1--checkoutio.myvtex.com/cart)

Add an item to cart, click the minicart icon and then click "Go to checkout". You should be sent to `/checkout/#/cart` (current Checkout) or `/cart` (new Checkout), depending on the workspace.

In workspaces with the current Minicart, if the `linkButtonFinishShopping` prop is set in Site Editor, it should take priority over the URL determined in the code. The same should happen with props defined in the blocks file.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
