### PR TITLE
Create new `minicart-empty-state` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `minicart-empty-state` interface.
 
 ## [2.32.1] - 2019-12-17
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,9 @@
     "vtex.device-detector": "0.x",
     "vtex.store-drawer": "0.x",
     "vtex.checkout-summary": "0.x",
-    "vtex.checkout-resources": "0.x"
+    "vtex.checkout-resources": "0.x",
+    "vtex.flex-layout": "0.x",
+    "vtex.rich-text": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -31,7 +31,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
     variation === 'drawer' ? 'pa4' : 'pv3'
   } sticky`
 
-  const isEmptyCart = !loading && orderForm.items.length === 0
+  const isCartEmpty = !loading && orderForm.items.length === 0
 
   return (
     <div className={minicartContentClasses}>
@@ -39,13 +39,13 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
         <h3 className="t-heading-3 mv2 c-on-base">
           <FormattedMessage id="store/minicart.title" />
         </h3>
-        {isEmptyCart ? (
+        {isCartEmpty ? (
           <ExtensionPoint id="minicart-empty-state" />
         ) : (
           <ExtensionPoint id="minicart-product-list" />
         )}
       </div>
-      {!isEmptyCart && (
+      {!isCartEmpty && (
         <div className={minicartFooterClasses}>
           <ExtensionPoint id="minicart-summary" />
           <Button

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -15,12 +15,7 @@ interface Props {
   finishShoppingButtonLink: string
 }
 
-const CSS_HANDLES = [
-  'minicartContent',
-  'minicartFooter',
-  'minicartEmptyStateText',
-  'minicartEmptyStateContainer',
-] as const
+const CSS_HANDLES = ['minicartContent', 'minicartFooter'] as const
 
 const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
   const { orderForm, loading }: OrderFormContext = useOrderForm()
@@ -36,33 +31,33 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
     variation === 'drawer' ? 'pa4' : 'pv3'
   } sticky`
 
-  const emptyStateClasses = `${handles.minicartEmptyStateContainer} ${styles.minicartEmptyStateContainerDefault} pa9 flex justify-center`
+  const isEmptyCart = !loading && orderForm.items.length === 0
 
-  return !loading && orderForm.items.length === 0 ? (
-    <div className={emptyStateClasses}>
-      <span className={`${handles.minicartEmptyStateText} t-body`}>
-        <FormattedMessage id="store/minicart.empty-state" />
-      </span>
-    </div>
-  ) : (
+  return (
     <div className={minicartContentClasses}>
       <div className="w-100 overflow-y-auto">
         <h3 className="t-heading-3 mv2 c-on-base">
           <FormattedMessage id="store/minicart.title" />
         </h3>
-        <ExtensionPoint id="minicart-product-list" />
+        {isEmptyCart ? (
+          <ExtensionPoint id="minicart-empty-state" />
+        ) : (
+          <ExtensionPoint id="minicart-product-list" />
+        )}
       </div>
-      <div className={minicartFooterClasses}>
-        <ExtensionPoint id="minicart-summary" />
-        <Button
-          id="proceed-to-checkout"
-          href={finishShoppingButtonLink || checkoutUrl}
-          variation="primary"
-          block
-        >
-          <FormattedMessage id="store/minicart.go-to-checkout" />
-        </Button>
-      </div>
+      {!isEmptyCart && (
+        <div className={minicartFooterClasses}>
+          <ExtensionPoint id="minicart-summary" />
+          <Button
+            id="proceed-to-checkout"
+            href={finishShoppingButtonLink || checkoutUrl}
+            variation="primary"
+            block
+          >
+            <FormattedMessage id="store/minicart.go-to-checkout" />
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/react/EmptyState.tsx
+++ b/react/EmptyState.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['minicartEmptyStateContainer'] as const
+
+const EmptyState: FC = ({ children }) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return <div className={handles.minicartEmptyStateContainer}>{children}</div>
+}
+
+export default EmptyState

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -4,7 +4,11 @@
     "children": ["minicart-base-content"]
   },
   "minicart-base-content": {
-    "blocks": ["minicart-product-list", "minicart-summary"]
+    "blocks": [
+      "minicart-product-list",
+      "minicart-summary",
+      "minicart-empty-state"
+    ]
   },
   "minicart-product-list": {
     "blocks": ["product-list"]
@@ -23,6 +27,20 @@
     "props": {
       "showTotal": true,
       "showDeliveryTotal": false
+    }
+  },
+  "minicart-empty-state": {
+    "children": ["flex-layout.row#empty-state"]
+  },
+  "flex-layout.row#empty-state": {
+    "children": ["flex-layout.col#empty-state"]
+  },
+  "flex-layout.col#empty-state": {
+    "children": ["rich-text#empty-state"]
+  },
+  "rich-text#empty-state": {
+    "props": {
+      "text": "Your cart is empty!"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -11,7 +11,11 @@
   },
   "minicart-base-content": {
     "component": "BaseContent",
-    "allowed": ["minicart-product-list", "minicart-summary"]
+    "allowed": [
+      "minicart-product-list",
+      "minicart-summary",
+      "minicart-empty-state"
+    ]
   },
   "minicart-product-list": {
     "component": "ProductList",
@@ -20,5 +24,10 @@
   "minicart-summary": {
     "component": "Summary",
     "allowed": ["checkout-summary"]
+  },
+  "minicart-empty-state": {
+    "component": "EmptyState",
+    "composition": "children",
+    "allowed": "*"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support for custom empty minicarts.

#### What problem is this solving?

The user could not customize the look for the empty minicart.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
