### PR TITLE
Use the navigate function in order to benefit from apollo cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `render-runtime` `navigate` function to proceed to cart in order to benefit from apollo cache.
 
 ## [2.40.0] - 2020-01-27
 ### Added

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -43,11 +43,15 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
   const push = useDebouncedPush()
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
-  const { url: checkoutUrl } = useCheckoutURL()
+  const { url: checkoutUrl, major } = useCheckoutURL()
   const { navigate } = useRuntime()
 
   const goToCheckout = (url: string) => {
-    navigate({ to: url })
+    if (major) {
+      navigate({ to: url })
+    } else {
+      window.location.href = url
+    }
   }
 
   useEffect(() => {

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -47,7 +47,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
   const { navigate } = useRuntime()
 
   const goToCheckout = (url: string) => {
-    if (major && url === checkoutUrl) {
+    if (major > 0 && url === checkoutUrl) {
       navigate({ to: url })
     } else {
       window.location.href = url

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -7,7 +7,7 @@ import React, {
   memo,
 } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { ExtensionPoint, useRuntime } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 import { useCssHandles } from 'vtex.css-handles'
@@ -44,6 +44,11 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
+  const { navigate } = useRuntime()
+
+  const goToCheckout = (url: string) => {
+    navigate({ to: url })
+  }
 
   useEffect(() => {
     if (loading) {

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -7,7 +7,7 @@ import React, {
   memo,
 } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { ExtensionPoint, useRuntime } from 'vtex.render-runtime'
+import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 import { useCssHandles } from 'vtex.css-handles'
@@ -17,6 +17,7 @@ import { useMinicartState } from './MinicartContext'
 import styles from './styles.css'
 import { mapCartItemToPixel } from './modules/pixelHelper'
 import useDebouncedPush from './modules/debouncedPixelHook'
+import useCheckout from './modules/checkoutHook'
 
 interface Props {
   sideBarMode: boolean
@@ -43,16 +44,8 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
   const push = useDebouncedPush()
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
-  const { url: checkoutUrl, major } = useCheckoutURL()
-  const { navigate } = useRuntime()
-
-  const goToCheckout = (url: string) => {
-    if (major > 0 && url === checkoutUrl) {
-      navigate({ to: url })
-    } else {
-      window.location.href = url
-    }
-  }
+  const { url: checkoutUrl } = useCheckoutURL()
+  const goToCheckout = useCheckout()
 
   useEffect(() => {
     if (loading) {
@@ -108,7 +101,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
         <ExtensionPoint id="minicart-summary" />
         <Button
           id="proceed-to-checkout"
-          href={finishShoppingButtonLink || checkoutUrl}
+          onClick={() => goToCheckout(finishShoppingButtonLink || checkoutUrl)}
           variation="primary"
           block
         >

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -47,7 +47,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink, children }) => {
   const { navigate } = useRuntime()
 
   const goToCheckout = (url: string) => {
-    if (major) {
+    if (major && url === checkoutUrl) {
       navigate({ to: url })
     } else {
       window.location.href = url

--- a/react/CheckoutButton.tsx
+++ b/react/CheckoutButton.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
+import useCheckout from './modules/checkoutHook'
 
 interface Props {
   finishShoppingButtonLink: string
@@ -13,12 +14,13 @@ const CSS_HANDLES = ['minicartCheckoutButton'] as const
 const CheckoutButton: FC<Props> = ({ finishShoppingButtonLink }) => {
   const { url: checkoutUrl } = useCheckoutURL()
   const handles = useCssHandles(CSS_HANDLES)
+  const goToCheckout = useCheckout()
 
   return (
     <div className={`${handles.minicartCheckoutButton} mv3`}>
       <Button
         id="proceed-to-checkout"
-        href={finishShoppingButtonLink || checkoutUrl}
+        onClick={() => goToCheckout(finishShoppingButtonLink || checkoutUrl)}
         variation="primary"
         block
       >

--- a/react/modules/checkoutHook.ts
+++ b/react/modules/checkoutHook.ts
@@ -1,0 +1,17 @@
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
+import { useRuntime } from 'vtex.render-runtime'
+
+export default function useCheckout() {
+  const { url: checkoutUrl, major } = useCheckoutURL()
+  const { navigate } = useRuntime()
+
+  const goToCheckout = (url: string) => {
+    if (major > 0 && url === checkoutUrl) {
+      navigate({ to: url })
+    } else {
+      window.location.href = url
+    }
+  }
+
+  return goToCheckout
+}


### PR DESCRIPTION
#### Notes

This PR depends on and must be merged after the `checkout-resources` changes.

#### What is the purpose of this pull request?

As the title says, this PR adapts the minicart to use `render-runtime`'s navigate function.
<!--- Describe your changes in detail. -->

#### What problem is this solving?

The checkout's cart now can benefit from the apollo cache.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Open this [workspace](https://jeffaddepum--checkoutio.myvtex.com/)
- Add an item to cart
- Click on the cart icon at top right
- Proceed to cart
- Verify that the loading skeleton didn't appear

Alternatively, you can

- Add an item to cart
- Click on the cart icon at top right
- Open console dev tools
- Proceed to cart
- Verify that a request to get the `orderForm` is not being made

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
