### PR TITLE
Implement cartChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New pixel event `cartChanged` when an item is removed or added
+- New pixel event `cartChanged` when an item is removed or added.
 
 ### Fixed
 - Remove variant name from product name in `removeFromCart` event. Making the name consistent across events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New pixel event `cartChanged` when an item is removed or added
+
+### Fixed
+- Remove variant name from product name in `removeFromCart` event. Making the name consistent across events.
 
 ## [2.36.0] - 2020-01-06
 ### Changed

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
@@ -7,8 +7,9 @@ import { useCssHandles } from 'vtex.css-handles'
 import { Button } from 'vtex.styleguide'
 
 import { useMinicartState } from './MinicartContext'
-
 import styles from './styles.css'
+import { mapCartItemToPixel } from './modules/pixelHelper'
+import useDebouncedPush from './modules/debouncedPixelHook'
 
 interface Props {
   sideBarMode: boolean
@@ -24,9 +25,21 @@ const CSS_HANDLES = [
 
 const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
   const { orderForm, loading }: OrderFormContext = useOrderForm()
+  const push = useDebouncedPush()
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
+
+  useEffect(() => {
+    if (loading) {
+      return
+    }
+
+    push({
+      event: 'cartChanged',
+      items: orderForm.items.map(mapCartItemToPixel),
+    })
+  }, [push, loading, orderForm.items])
 
   const minicartContentClasses = `${handles.minicartContentContainer} ${
     variation === 'drawer' ? styles.drawerStyles : styles.popupStyles

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC } from 'react'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { OrderItemsProvider, useOrderItems } from 'vtex.order-items/OrderItems'
 import { ExtensionPoint } from 'vtex.render-runtime'
@@ -15,13 +15,6 @@ const ProductList: FC = () => {
   const { updateQuantity, removeItem } = useOrderItems()
   const { push } = usePixel()
   const handles = useCssHandles(CSS_HANDLES)
-
-  useEffect(() => {
-    push({
-      event: 'cartChanged',
-      items: items.map(mapCartItemToPixel)
-    })
-  }, [items])
 
   const handleQuantityChange = (
     uniqueId: string,

--- a/react/index.js
+++ b/react/index.js
@@ -23,7 +23,7 @@ import MiniCartContent from './legacy/components/MiniCartContent'
 import Sidebar from './legacy/components/Sidebar'
 import Popup from './legacy/components/Popup'
 import { shouldShowItem } from './legacy/utils/itemsHelper'
-import { mapBuyButtonItemToPixel } from './legacy/utils/pixelHelper'
+import { mapBuyButtonItemToPixel, mapCartItemToPixel } from './modules/pixelHelper'
 
 import fullMinicartQuery from './legacy/localState/graphql/fullMinicartQuery.gql'
 import updateItemsMutation from './legacy/localState/graphql/updateItemsMutation.gql'
@@ -305,6 +305,13 @@ const MiniCart = ({
             ['data', 'addItem'],
             addItemsResponse
           )
+
+          push({
+            event: 'cartChanged',
+            items: newOrderForm && newOrderForm.items
+              ? newOrderForm.items.map(mapCartItemToPixel)
+              : []
+          })
 
           setUpdatingOrderForm(false)
           await updateOrderForm(newOrderForm, true)

--- a/react/legacy/components/MiniCartContent.js
+++ b/react/legacy/components/MiniCartContent.js
@@ -12,7 +12,7 @@ import { IconDelete } from 'vtex.store-icons'
 
 import { MiniCartPropTypes } from '../utils/propTypes'
 import { toHttps, changeImageUrlSize } from '../utils/urlHelpers'
-import { mapCartItemToPixel } from '../utils/pixelHelper'
+import { mapCartItemToPixel } from '../../modules/pixelHelper'
 
 import { ITEMS_STATUS } from '../localState/index'
 import updateItemsMutation from '../localState/graphql/updateItemsMutation.gql'

--- a/react/modules/debouncedPixelHook.ts
+++ b/react/modules/debouncedPixelHook.ts
@@ -1,0 +1,10 @@
+import { useRef } from 'react'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import debounce from 'debounce'
+
+export default function useDebouncedPush() {
+  const { push } = usePixel()
+  const debouncedPush = useRef<(param: object) => void>(debounce(push, 600))
+
+  return debouncedPush.current
+}

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -3,7 +3,7 @@ export function mapCartItemToPixel(item: CartItem): PixelCartItem {
     skuId: item.id,
     variant: item.skuName,
     price: item.sellingPrice,
-    name: item.name,
+    name: getNameWithoutVariant(item),
     quantity: item.quantity,
     productRefId: item.productRefId,
     brand: item.additionalInfo ? item.additionalInfo.brandName : '',
@@ -26,6 +26,21 @@ export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
     brand: item.brand,
     category,
   }
+}
+
+/**
+ * Remove the variant from the end of the name.
+ * Ex: from "Classic Shoes Pink" to "Classic Shoes"
+ */
+function getNameWithoutVariant(item: CartItem) {
+  if (!item.name.includes(item.skuName)) {
+    return item.name
+  }
+
+  const leadingSpace = 1
+  const variantLength = leadingSpace + item.skuName.length
+
+  return item.name.slice(0, item.name.length - variantLength)
 }
 
 function productCategory(item: CartItem) {

--- a/react/package.json
+++ b/react/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
+    "@types/debounce": "^1.2.0",
     "@vtex/test-tools": "3.0.0",
     "apollo-cache-inmemory": "^1.5.1",
     "babel-eslint": "^10.0.1",
@@ -23,6 +24,7 @@
   "dependencies": {
     "apollo-client": "2.6.4",
     "classnames": "^2.2.6",
+    "debounce": "^1.2.0",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",
     "hoist-non-react-statics": "^3.3.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1253,6 +1253,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/debounce@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2242,6 +2247,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new event of cartChanged to be available to pixel apps.

#### What problem is this solving?

Listrak is a pixel app that needs to trigger an event with every item in the cart. Previously we only offered addToCart and removeFromCart, making it difficult for a pixel app to deal with this kind of event that needs the whole cart items.

#### How should this be manually tested?

With the new minicart
https://breno2--storecomponents.myvtex.com/

With the old minicart
https://breno--worldwidegolf.myvtex.com/

Check the events being printed in the console.

1. Add to cart from Shelf
2. Add to cart from search result
3. Add to cart from product page
4. Change quantity in minicart
5. Remove item from minicart

#### Screenshots or example usage


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
