### PR TITLE
Fix a bug that prevented `BaseContent` to fill all available height available to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Missing `h-100` token on `minicart-base-content`.
 
 ## [2.37.0] - 2020-01-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fix
+### Fixed
 - Missing `h-100` token on `minicart-base-content`.
 
 ## [2.37.0] - 2020-01-09

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -54,7 +54,7 @@ const Content: FC<Props> = ({ finishShoppingButtonLink }) => {
   return (
     <div className={minicartContentClasses}>
       <div
-        className={`w-100 overflow-y-auto ${handles.minicartProductListContainer}`}
+        className={`w-100 h-100 overflow-y-auto ${handles.minicartProductListContainer}`}
       >
         <h3 className={`${handles.minicartTitle} t-heading-3 mv2 c-on-base`}>
           <FormattedMessage id="store/minicart.title" />


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a layout bug in `minicart-base-content`.

#### What problem is this solving?

Custom CSS could break `minicart.v2` layout as the BaseContent would not fill the available height.

#### How should this be manually tested?

[Workspace](https://minicartfix--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
