### PR TITLE
Add new fields 'detailUrl' and 'imageUrl' to cart events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New fields `detailUrl` and `imageUrl` to items in `addToCart`, `removeFromCart` and `cartChanged` events.
 
 ## [2.37.1] - 2020-01-09
 ### Fixed

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -8,6 +8,8 @@ export function mapCartItemToPixel(item: CartItem): PixelCartItem {
     productRefId: item.productRefId,
     brand: item.additionalInfo ? item.additionalInfo.brandName : '',
     category: productCategory(item),
+    detailUrl: item.detailUrl,
+    imageUrl: item.imageUrls ? item.imageUrls.at3x : item.imageUrl || '',
   }
 }
 
@@ -25,6 +27,8 @@ export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
     productRefId: item.productRefId,
     brand: item.brand,
     category,
+    detailUrl: item.detailUrl,
+    imageUrl: item.imageUrl,
   }
 }
 
@@ -63,6 +67,8 @@ interface PixelCartItem {
   productRefId: string
   brand: string
   category: string
+  detailUrl: string
+  imageUrl: string
 }
 
 interface BuyButtonItem {
@@ -74,6 +80,8 @@ interface BuyButtonItem {
   productRefId: string
   brand: string
   category: string
+  detailUrl: string
+  imageUrl: string
 }
 
 interface CartItem {
@@ -88,4 +96,13 @@ interface CartItem {
   }
   productCategoryIds: string
   productCategories: Record<string, string>
+  detailUrl: string
+  // Field from the usual orderForm API
+  imageUrl?: string
+  // Field from the order-manager orderForm API
+  imageUrls?: {
+    at1x: string
+    at2x: string
+    at3x: string
+  }
 }

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -9,7 +9,9 @@ export function mapCartItemToPixel(item: CartItem): PixelCartItem {
     brand: item.additionalInfo ? item.additionalInfo.brandName : '',
     category: productCategory(item),
     detailUrl: item.detailUrl,
-    imageUrl: item.imageUrls ? item.imageUrls.at3x : item.imageUrl || '',
+    imageUrl: item.imageUrls
+      ? fixUrlProtocol(item.imageUrls.at3x)
+      : item.imageUrl || '',
   }
 }
 
@@ -30,6 +32,18 @@ export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
     detailUrl: item.detailUrl,
     imageUrl: item.imageUrl,
   }
+}
+
+/**
+ * URL comes like "//storecomponents.vteximg.com.br/arquivos/ids/155491"
+ * this function guarantees it comes with protocol in it.
+ */
+function fixUrlProtocol(url: string) {
+  if (!url || url.indexOf('http') === 0) {
+    return url
+  }
+
+  return 'https:' + url
 }
 
 /**


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add new fields to pixel events so it's possible to develop the Listrak pixel.

#### How should this be manually tested?

Old minicart:
https://breno--storecomponents.myvtex.com/gorgeous-watch/p

New minicart:
https://brenonew--storecomponents.myvtex.com/gorgeous-watch/p

Check for the events in the console and verify the existence of detailUrl and imageUrl when:
1. Adding an item via shelf
2. Adding an item via product page
3. Removing an item via minicart
4. Increasing a quantity via minicart

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
