### PR TITLE
Add new CSS handle for `minicart` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `labelDiscountText` CSS handle to `minicart`.
 
 ## [2.37.1] - 2020-01-09
 ### Fixed

--- a/react/legacy/components/MiniCartFooter.js
+++ b/react/legacy/components/MiniCartFooter.js
@@ -73,7 +73,11 @@ const MiniCartFooter = ({
       <div className={footerClasses}>
         {!isUpdating && showDiscount && discount > 0 && (
           <div className={priceAndDiscountClasses}>
-            <span className="ttl c-action-primary">{labelDiscount}</span>
+            <span
+              className={`${minicart.labelDiscountText} ttl c-action-primary`}
+            >
+              {labelDiscount}
+            </span>
             <ProductPrice
               sellingPriceClass="c-action-primary t-body ph2 dib"
               sellingPrice={discount}

--- a/react/legacy/minicart.css
+++ b/react/legacy/minicart.css
@@ -86,6 +86,9 @@
 .sidebarItemQuantityContainer {
 }
 
+.labelDiscountText{
+}
+
 @media only screen and (max-width: 40rem) {
   body.sidebarOpen {
     overflow: hidden;


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a new `labelDiscountText` CSS handle.

#### What problem is this solving?

Solves this issue: https://app.clubhouse.io/vtex/story/29376/add-missing-css-handles-in-minicart

#### How should this be manually tested?

https://minicart--storecomponents.myvtex.com/
https://minicartcsshandles--tbb.myvtex.com/
https://minicartcsshandles--boticario.myvtex.com/

#### Screenshots or example usage

![Screen Shot 2020-01-15 at 16 57 20](https://user-images.githubusercontent.com/27777263/72466688-21df1680-37b8-11ea-995f-c99e5f129a5d.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
