### PR TITLE
Create new `content` block/interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `minicart-content` block with composition children.
 
 ## [2.37.1] - 2020-01-09
 ### Fixed

--- a/react/Content.tsx
+++ b/react/Content.tsx
@@ -1,0 +1,5 @@
+import React, { FC, Fragment } from 'react'
+
+const Content: FC = ({ children }) => <Fragment>{children}</Fragment>
+
+export default Content

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -1,18 +1,47 @@
 import React, { FC } from 'react'
+import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
+import { Button } from 'vtex.styleguide'
+import { useCssHandles } from 'vtex.css-handles'
 
-const Summary: FC = () => {
+import { useMinicartState } from './MinicartContext'
+
+interface Props {
+  finishShoppingButtonLink: string
+}
+
+const CSS_HANDLES = ['minicartFooter'] as const
+
+const Summary: FC<Props> = ({ finishShoppingButtonLink }) => {
   const {
     orderForm: { totalizers, value },
   } = useOrderForm()
+  const { url: checkoutUrl } = useCheckoutURL()
+  const { variation } = useMinicartState()
+  const handles = useCssHandles(CSS_HANDLES)
+
+  const minicartFooterClasses = `${handles.minicartFooter} ${
+    variation === 'drawer' ? 'pa4' : 'pv3'
+  } sticky`
 
   return (
-    <ExtensionPoint
-      id="checkout-summary"
-      totalizers={totalizers}
-      total={value}
-    />
+    <div className={minicartFooterClasses}>
+      <ExtensionPoint
+        id="checkout-summary"
+        totalizers={totalizers}
+        total={value}
+      />
+      <Button
+        id="proceed-to-checkout"
+        href={finishShoppingButtonLink || checkoutUrl}
+        variation="primary"
+        block
+      >
+        <FormattedMessage id="store/minicart.go-to-checkout" />
+      </Button>
+    </div>
   )
 }
 

--- a/react/components/DrawerMode.tsx
+++ b/react/components/DrawerMode.tsx
@@ -26,7 +26,7 @@ const DrawerMode: FC<Props> = ({
       customIcon={<MinicartIconButton />}
     >
       <div
-        className={`${handles.minicartSideBarContentWrapper} w-100 h-100 ph4`}
+        className={`${handles.minicartSideBarContentWrapper} w-100 ph4`}
         style={{
           height: window.innerHeight - DRAWER_CLOSE_ICON_HEIGHT,
         }}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -8,12 +8,18 @@
     "composition": "children",
     "allowed": "*"
   },
+  "minicart-content": {
+    "component": "Content",
+    "composition": "children",
+    "allowed": "*"
+  },
   "minicart-base-content": {
     "component": "BaseContent",
     "allowed": [
       "minicart-product-list",
       "minicart-summary",
-      "minicart-empty-state"
+      "minicart-empty-state",
+      "minicart-content"
     ],
     "render": "lazy"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Create a new `content` block, which has `composition: "children"`.

#### What problem is this solving?

This should enable users to further customize the minicart.

#### How should this be manually tested?

Just go to this [workspace](https://minicartchildren--storecomponents.myvtex.com/) and add a few items to the minicart and see that there is a `rich-text` right above the `minicart-summary` block. This `rich-text` was placed there via `children`:

```json
"minicart.v2": {
    "children": ["minicart-base-content"]
  },
  "minicart-base-content": {
    "blocks": ["minicart-content", "minicart-empty-state"]
  },
  "minicart-content": {
    "children": [
      "minicart-product-list",
      "flex-layout.row#extension-point-demo",
      "minicart-summary"
    ]
  },

  "flex-layout.row#extension-point-demo": {
    "children": ["flex-layout.col#extension-point-demo"]
  },
  "flex-layout.col#extension-point-demo": {
    "children": ["rich-text#extension-point-demo"]
  },
  "rich-text#extension-point-demo": {
    "props": {
      "text": "This is a rich text passed as a child to minicart-content"
    }
  },
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
