### PR TITLE
Update logic for openOnHover behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Popup minicart behavior when `openOnHover` is set to `true`.
 
 ## [2.41.0] - 2020-01-29
 ### Changed

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -9,7 +9,7 @@ interface CloseMinicartAction {
 }
 interface SetOpenOnHoverBehaviorAction {
   type: 'SET_OPEN_ON_HOVER_BEHAVIOR'
-  value: boolean
+  value: 'click' | 'hover'
 }
 
 interface State {
@@ -17,7 +17,7 @@ interface State {
   open: boolean
   hasBeenOpened: boolean
   /** Whether or not the expected openOnHover behavior is active */
-  openOnHoverBehavior: boolean
+  openBehavior: 'click' | 'hover'
   /** Value provided by the user to openOnHover prop */
   openOnHoverProp: boolean
 }
@@ -52,7 +52,7 @@ function minicartContextReducer(state: State, action: Action): State {
     case 'SET_OPEN_ON_HOVER_BEHAVIOR':
       return {
         ...state,
-        openOnHoverBehavior: action.value,
+        openBehavior: action.value,
       }
     default:
       return state
@@ -75,8 +75,8 @@ const MinicartContextProvider: FC<Props> = ({
     open: false,
     hasBeenOpened: false,
     openOnHoverProp,
-    openOnHoverBehavior:
-      resolvedVariation === 'popup' ? openOnHoverProp : false,
+    openBehavior:
+      resolvedVariation === 'popup' && openOnHoverProp ? 'hover' : 'click',
   })
 
   return (

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -7,12 +7,17 @@ interface OpenMinicartAction {
 interface CloseMinicartAction {
   type: 'CLOSE_MINICART'
 }
+interface SetOpenOnHoverBehaviorAction {
+  type: 'SET_OPEN_ON_HOVER_BEHAVIOR'
+  value: boolean
+}
 
 interface State {
   variation: MinicartVariationType
   open: boolean
   hasBeenOpened: boolean
-  openOnHover: boolean
+  openOnHoverBehavior: boolean
+  openOnHoverProp: boolean
 }
 
 interface Props {
@@ -20,7 +25,10 @@ interface Props {
   variation: MinicartVariationType
 }
 
-type Action = OpenMinicartAction | CloseMinicartAction
+type Action =
+  | OpenMinicartAction
+  | CloseMinicartAction
+  | SetOpenOnHoverBehaviorAction
 type Dispatch = (action: Action) => void
 
 const MinicartStateContext = createContext<State | undefined>(undefined)
@@ -38,6 +46,11 @@ function minicartContextReducer(state: State, action: Action): State {
       return {
         ...state,
         open: false,
+      }
+    case 'SET_OPEN_ON_HOVER_BEHAVIOR':
+      return {
+        ...state,
+        openOnHoverBehavior: action.value,
       }
     default:
       return state
@@ -57,7 +70,9 @@ const MinicartContextProvider: FC<Props> = ({
     variation: resolvedVariation,
     open: false,
     hasBeenOpened: false,
-    openOnHover: resolvedVariation !== 'popup' ? false : openOnHover,
+    openOnHoverProp: openOnHover,
+    openOnHoverBehavior:
+      resolvedVariation === 'popup' && !isMobile ? openOnHover : false,
   })
 
   return (

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -16,7 +16,7 @@ interface State {
   variation: MinicartVariationType
   open: boolean
   hasBeenOpened: boolean
-  /** Whether or not the expected openOnHover behavior is active */
+  /** Controls the minicart opening behavior */
   openBehavior: 'click' | 'hover'
   /** Value provided by the user to openOnHover prop */
   openOnHoverProp: boolean

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -8,7 +8,7 @@ interface CloseMinicartAction {
   type: 'CLOSE_MINICART'
 }
 interface SetOpenOnHoverBehaviorAction {
-  type: 'SET_OPEN_ON_HOVER_BEHAVIOR'
+  type: 'SET_OPEN_BEHAVIOR'
   value: 'click' | 'hover'
 }
 
@@ -49,7 +49,7 @@ function minicartContextReducer(state: State, action: Action): State {
         ...state,
         open: false,
       }
-    case 'SET_OPEN_ON_HOVER_BEHAVIOR':
+    case 'SET_OPEN_BEHAVIOR':
       return {
         ...state,
         openBehavior: action.value,

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -16,7 +16,9 @@ interface State {
   variation: MinicartVariationType
   open: boolean
   hasBeenOpened: boolean
+  /** Whether or not the expected openOnHover behavior is active */
   openOnHoverBehavior: boolean
+  /** Value provided by the user to openOnHover prop */
   openOnHoverProp: boolean
 }
 
@@ -59,10 +61,12 @@ function minicartContextReducer(state: State, action: Action): State {
 
 const MinicartContextProvider: FC<Props> = ({
   variation = 'drawer',
-  openOnHover = false,
+  openOnHover: openOnHoverProp = false,
   children,
 }) => {
   const { isMobile } = useDevice()
+
+  // This prevents a popup minicart from being used on a mobile device
   const resolvedVariation =
     isMobile || (window && window.innerWidth <= 480) ? 'drawer' : variation
 
@@ -70,9 +74,9 @@ const MinicartContextProvider: FC<Props> = ({
     variation: resolvedVariation,
     open: false,
     hasBeenOpened: false,
-    openOnHoverProp: openOnHover,
+    openOnHoverProp,
     openOnHoverBehavior:
-      resolvedVariation === 'popup' && !isMobile ? openOnHover : false,
+      resolvedVariation === 'popup' ? openOnHoverProp : false,
   })
 
   return (

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -7,7 +7,7 @@ interface OpenMinicartAction {
 interface CloseMinicartAction {
   type: 'CLOSE_MINICART'
 }
-interface SetOpenOnHoverBehaviorAction {
+interface SetOpenBehaviorAction {
   type: 'SET_OPEN_BEHAVIOR'
   value: 'click' | 'hover'
 }
@@ -27,10 +27,7 @@ interface Props {
   variation: MinicartVariationType
 }
 
-type Action =
-  | OpenMinicartAction
-  | CloseMinicartAction
-  | SetOpenOnHoverBehaviorAction
+type Action = OpenMinicartAction | CloseMinicartAction | SetOpenBehaviorAction
 type Dispatch = (action: Action) => void
 
 const MinicartStateContext = createContext<State | undefined>(undefined)

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -47,6 +47,7 @@ const ProductList: FC<Props> = ({ renderAsChildren }) => {
 
   return (
     <div
+      onMouseLeave={e => e.stopPropagation()}
       className={`${handles.minicartProductListContainer} ${
         renderAsChildren ? 'w-100 h-100' : ''
       } overflow-y-auto`}

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -47,6 +47,10 @@ const ProductList: FC<Props> = ({ renderAsChildren }) => {
 
   return (
     <div
+      // This prevents an interaction with the quantity selector
+      // inside of a product in the ProductList to bubble up a
+      // mouseleave event to the Popup component, which would result
+      // in the minicart being closed (when openOnHover = true).
       onMouseLeave={e => e.stopPropagation()}
       className={`${handles.minicartProductListContainer} ${
         renderAsChildren ? 'w-100 h-100' : ''

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -47,10 +47,12 @@ const ProductList: FC<Props> = ({ renderAsChildren }) => {
 
   return (
     <div
-      // This prevents an interaction with the quantity selector
-      // inside of a product in the ProductList to bubble up a
-      // mouseleave event to the Popup component, which would result
-      // in the minicart being closed (when openOnHover = true).
+      /* 
+        This prevents an interaction with the quantity selector
+        inside of a product in the ProductList to bubble up a
+        mouseleave event to the Popup component, which would result
+        in the minicart being closed (when openOnHover = true). 
+      */
       onMouseLeave={e => e.stopPropagation()}
       className={`${handles.minicartProductListContainer} ${
         renderAsChildren ? 'w-100 h-100' : ''

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -12,23 +12,23 @@ const CSS_HANDLES = ['minicartIconContainer', 'minicartQuantityBadge'] as const
 const MinicartIconButton = () => {
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const handles = useCssHandles(CSS_HANDLES)
-  const { open, openOnHoverBehavior, openOnHoverProp } = useMinicartState()
+  const { open, openBehavior, openOnHoverProp } = useMinicartState()
   const dispatch = useMinicartDispatch()
   const itemQuantity = loading ? 0 : orderForm.items.length
 
   const handleClick = () => {
     if (openOnHoverProp) {
-      if (openOnHoverBehavior) {
+      if (openBehavior === 'hover') {
         dispatch({
           type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-          value: false,
+          value: 'click',
         })
         return
       }
       dispatch({ type: 'CLOSE_MINICART' })
       dispatch({
         type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-        value: true,
+        value: 'hover',
       })
       return
     }
@@ -52,7 +52,7 @@ const MinicartIconButton = () => {
       }
       variation="tertiary"
       onMouseEnter={
-        openOnHoverBehavior
+        openBehavior === 'hover'
           ? () => dispatch({ type: 'OPEN_MINICART' })
           : undefined
       }

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -20,14 +20,14 @@ const MinicartIconButton = () => {
     if (openOnHoverProp) {
       if (openBehavior === 'hover') {
         dispatch({
-          type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+          type: 'SET_OPEN_BEHAVIOR',
           value: 'click',
         })
         return
       }
       dispatch({ type: 'CLOSE_MINICART' })
       dispatch({
-        type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+        type: 'SET_OPEN_BEHAVIOR',
         value: 'hover',
       })
       return

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -24,6 +24,7 @@ const MinicartIconButton = () => {
           <IconCart />
           {itemQuantity > 0 && (
             <span
+              style={{ userSelect: 'none' }}
               className={`${handles.minicartQuantityBadge} ${styles.minicartQuantityBadgeDefault} c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
             >
               {itemQuantity}

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -17,22 +17,22 @@ const MinicartIconButton = () => {
   const itemQuantity = loading ? 0 : orderForm.items.length
 
   const handleClick = () => {
-    if (!openOnHoverProp) {
-      dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
-      return
-    }
-    if (openOnHoverBehavior) {
+    if (openOnHoverProp) {
+      if (openOnHoverBehavior) {
+        dispatch({
+          type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+          value: false,
+        })
+        return
+      }
+      dispatch({ type: 'CLOSE_MINICART' })
       dispatch({
         type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-        value: false,
+        value: true,
       })
       return
     }
-    dispatch({ type: 'CLOSE_MINICART' })
-    dispatch({
-      type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-      value: true,
-    })
+    dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
   }
 
   return (

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -12,7 +12,7 @@ const CSS_HANDLES = ['minicartIconContainer', 'minicartQuantityBadge'] as const
 const MinicartIconButton = () => {
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const handles = useCssHandles(CSS_HANDLES)
-  const { open, openOnHover } = useMinicartState()
+  const { open, openOnHoverBehavior, openOnHoverProp } = useMinicartState()
   const dispatch = useMinicartDispatch()
 
   const itemQuantity = loading ? 0 : orderForm.items.length
@@ -22,7 +22,9 @@ const MinicartIconButton = () => {
       icon={
         <span
           onMouseEnter={
-            openOnHover ? () => dispatch({ type: 'OPEN_MINICART' }) : undefined
+            openOnHoverBehavior
+              ? () => dispatch({ type: 'OPEN_MINICART' })
+              : undefined
           }
           className={`${handles.minicartIconContainer} gray relative`}
         >
@@ -37,9 +39,28 @@ const MinicartIconButton = () => {
         </span>
       }
       variation="tertiary"
-      onClick={() =>
-        dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
-      }
+      onClick={() => {
+        if (!openOnHoverProp) {
+          dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
+          return
+        }
+        if (openOnHoverBehavior) {
+          dispatch({
+            type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+            value: false,
+          })
+          return
+        }
+        if (open) {
+          dispatch({ type: 'CLOSE_MINICART' })
+          dispatch({
+            type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+            value: true,
+          })
+          return
+        }
+        dispatch({ type: 'OPEN_MINICART' })
+      }}
     />
   )
 }

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -20,14 +20,7 @@ const MinicartIconButton = () => {
   return (
     <ButtonWithIcon
       icon={
-        <span
-          onMouseEnter={
-            openOnHoverBehavior
-              ? () => dispatch({ type: 'OPEN_MINICART' })
-              : undefined
-          }
-          className={`${handles.minicartIconContainer} gray relative`}
-        >
+        <span className={`${handles.minicartIconContainer} gray relative`}>
           <IconCart />
           {itemQuantity > 0 && (
             <span
@@ -39,6 +32,11 @@ const MinicartIconButton = () => {
         </span>
       }
       variation="tertiary"
+      onMouseEnter={
+        openOnHoverBehavior
+          ? () => dispatch({ type: 'OPEN_MINICART' })
+          : undefined
+      }
       onClick={() => {
         if (!openOnHoverProp) {
           dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
@@ -51,15 +49,11 @@ const MinicartIconButton = () => {
           })
           return
         }
-        if (open) {
-          dispatch({ type: 'CLOSE_MINICART' })
-          dispatch({
-            type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-            value: true,
-          })
-          return
-        }
-        dispatch({ type: 'OPEN_MINICART' })
+        dispatch({ type: 'CLOSE_MINICART' })
+        dispatch({
+          type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+          value: true,
+        })
       }}
     />
   )

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -14,8 +14,26 @@ const MinicartIconButton = () => {
   const handles = useCssHandles(CSS_HANDLES)
   const { open, openOnHoverBehavior, openOnHoverProp } = useMinicartState()
   const dispatch = useMinicartDispatch()
-
   const itemQuantity = loading ? 0 : orderForm.items.length
+
+  const handleClick = () => {
+    if (!openOnHoverProp) {
+      dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
+      return
+    }
+    if (openOnHoverBehavior) {
+      dispatch({
+        type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+        value: false,
+      })
+      return
+    }
+    dispatch({ type: 'CLOSE_MINICART' })
+    dispatch({
+      type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
+      value: true,
+    })
+  }
 
   return (
     <ButtonWithIcon
@@ -38,24 +56,7 @@ const MinicartIconButton = () => {
           ? () => dispatch({ type: 'OPEN_MINICART' })
           : undefined
       }
-      onClick={() => {
-        if (!openOnHoverProp) {
-          dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
-          return
-        }
-        if (openOnHoverBehavior) {
-          dispatch({
-            type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-            value: false,
-          })
-          return
-        }
-        dispatch({ type: 'CLOSE_MINICART' })
-        dispatch({
-          type: 'SET_OPEN_ON_HOVER_BEHAVIOR',
-          value: true,
-        })
-      }}
+      onClick={handleClick}
     />
   )
 }

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -39,7 +39,7 @@ const PopupMode: FC = ({ children }) => {
   }
 
   return (
-    <div onMouseLeave={handleMouseLeave}>
+    <div onMouseLeave={openOnHoverProp ? handleMouseLeave : undefined}>
       <MinicartIconButton />
       {open && (
         <Overlay>

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { FC, Fragment } from 'react'
+import React, { FC } from 'react'
 import { Overlay } from 'vtex.react-portal'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -25,44 +25,49 @@ const PopupMode: FC = ({ children }) => {
   const dispatch = useMinicartDispatch()
   const handles = useCssHandles(CSS_HANDLES)
 
+  const clickHandler = () => {
+    if (openOnHoverProp) {
+      dispatch({ type: 'SET_OPEN_ON_HOVER_BEHAVIOR', value: true })
+    }
+    dispatch({ type: 'CLOSE_MINICART' })
+  }
+  const mouseLeaveHandler = () => {
+    if (!openOnHoverBehavior) {
+      return
+    }
+    dispatch({ type: 'CLOSE_MINICART' })
+  }
+
   return (
-    <Fragment>
-      <div
-        onMouseLeave={
-          openOnHoverBehavior
-            ? () => dispatch({ type: 'CLOSE_MINICART' })
-            : undefined
-        }
-      >
-        <MinicartIconButton />
-        {open && (
-          <Overlay>
-            {!openOnHoverProp && (
-              <div
-                className="fixed top-0 left-0 w-100 h-100"
-                onClick={() => dispatch({ type: 'CLOSE_MINICART' })}
-              />
-            )}
+    <div onMouseLeave={mouseLeaveHandler}>
+      <MinicartIconButton />
+      {open && (
+        <Overlay>
+          {!openOnHoverBehavior && (
             <div
-              className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-colunm`}
+              className="fixed top-0 left-0 w-100 h-100"
+              onClick={clickHandler}
+            />
+          )}
+          <div
+            className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-colunm`}
+          >
+            <div
+              className={`${handles.popupContentContainer} w-100 shadow-3 bg-base`}
             >
               <div
-                className={`${handles.popupContentContainer} w-100 shadow-3 bg-base`}
+                className={`${handles.arrowUp} ${styles.popupArrowUp} absolute top-0 bg-base h1 w1 pa4 rotate-45`}
+              />
+              <div
+                className={`${handles.popupChildrenContainer} mt3 bg-base relative flex flex-column ph5 pv3`}
               >
-                <div
-                  className={`${handles.arrowUp} ${styles.popupArrowUp} absolute top-0 bg-base h1 w1 pa4 rotate-45`}
-                />
-                <div
-                  className={`${handles.popupChildrenContainer} mt3 bg-base relative flex flex-column ph5 pv3`}
-                >
-                  {hasBeenOpened && children}
-                </div>
+                {hasBeenOpened && children}
               </div>
             </div>
-          </Overlay>
-        )}
-      </div>
-    </Fragment>
+          </div>
+        </Overlay>
+      )}
+    </div>
   )
 }
 

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -53,7 +53,6 @@ const PopupMode: FC = ({ children }) => {
                   className={`${handles.arrowUp} ${styles.popupArrowUp} absolute top-0 bg-base h1 w1 pa4 rotate-45`}
                 />
                 <div
-                  onMouseLeave={e => e.stopPropagation()}
                   className={`${handles.popupChildrenContainer} mt3 bg-base relative flex flex-column ph5 pv3`}
                 >
                   {hasBeenOpened && children}

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -16,42 +16,53 @@ const CSS_HANDLES = [
 ]
 
 const PopupMode: FC = ({ children }) => {
-  const { open, hasBeenOpened, openOnHover } = useMinicartState()
+  const {
+    open,
+    hasBeenOpened,
+    openOnHoverBehavior,
+    openOnHoverProp,
+  } = useMinicartState()
   const dispatch = useMinicartDispatch()
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
     <Fragment>
-      <MinicartIconButton />
-      {open && (
-        <Overlay>
-          <div
-            className="fixed top-0 left-0 w-100 h-100"
-            onClick={() => dispatch({ type: 'CLOSE_MINICART' })}
-          />
-          <div
-            onMouseLeave={
-              openOnHover
-                ? () => dispatch({ type: 'CLOSE_MINICART' })
-                : undefined
-            }
-            className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-colunm`}
-          >
+      <div
+        onMouseLeave={
+          openOnHoverBehavior
+            ? () => dispatch({ type: 'CLOSE_MINICART' })
+            : undefined
+        }
+      >
+        <MinicartIconButton />
+        {open && (
+          <Overlay>
+            {!openOnHoverProp && (
+              <div
+                className="fixed top-0 left-0 w-100 h-100"
+                onClick={() => dispatch({ type: 'CLOSE_MINICART' })}
+              />
+            )}
             <div
-              className={`${handles.popupContentContainer} w-100 shadow-3 bg-base`}
+              className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-colunm`}
             >
               <div
-                className={`${handles.arrowUp} ${styles.popupArrowUp} absolute top-0 bg-base h1 w1 pa4 rotate-45`}
-              />
-              <div
-                className={`${handles.popupChildrenContainer} mt3 bg-base relative flex flex-column ph5 pv3`}
+                className={`${handles.popupContentContainer} w-100 shadow-3 bg-base`}
               >
-                {hasBeenOpened && children}
+                <div
+                  className={`${handles.arrowUp} ${styles.popupArrowUp} absolute top-0 bg-base h1 w1 pa4 rotate-45`}
+                />
+                <div
+                  onMouseLeave={e => e.stopPropagation()}
+                  className={`${handles.popupChildrenContainer} mt3 bg-base relative flex flex-column ph5 pv3`}
+                >
+                  {hasBeenOpened && children}
+                </div>
               </div>
             </div>
-          </div>
-        </Overlay>
-      )}
+          </Overlay>
+        )}
+      </div>
     </Fragment>
   )
 }

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -27,7 +27,7 @@ const PopupMode: FC = ({ children }) => {
 
   const handleClick = () => {
     if (openOnHoverProp) {
-      dispatch({ type: 'SET_OPEN_ON_HOVER_BEHAVIOR', value: 'hover' })
+      dispatch({ type: 'SET_OPEN_BEHAVIOR', value: 'hover' })
     }
     dispatch({ type: 'CLOSE_MINICART' })
   }

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -19,7 +19,7 @@ const PopupMode: FC = ({ children }) => {
   const {
     open,
     hasBeenOpened,
-    openOnHoverBehavior,
+    openBehavior,
     openOnHoverProp,
   } = useMinicartState()
   const dispatch = useMinicartDispatch()
@@ -27,23 +27,20 @@ const PopupMode: FC = ({ children }) => {
 
   const handleClick = () => {
     if (openOnHoverProp) {
-      dispatch({ type: 'SET_OPEN_ON_HOVER_BEHAVIOR', value: true })
+      dispatch({ type: 'SET_OPEN_ON_HOVER_BEHAVIOR', value: 'hover' })
     }
     dispatch({ type: 'CLOSE_MINICART' })
   }
   const handleMouseLeave = () => {
-    if (!openOnHoverBehavior) {
-      return
-    }
     dispatch({ type: 'CLOSE_MINICART' })
   }
 
   return (
-    <div onMouseLeave={openOnHoverProp ? handleMouseLeave : undefined}>
+    <div onMouseLeave={openBehavior === 'hover' ? handleMouseLeave : undefined}>
       <MinicartIconButton />
       {open && (
         <Overlay>
-          {!openOnHoverBehavior && (
+          {openBehavior === 'click' && (
             <div
               className="fixed top-0 left-0 w-100 h-100"
               onClick={handleClick}

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -25,13 +25,13 @@ const PopupMode: FC = ({ children }) => {
   const dispatch = useMinicartDispatch()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const clickHandler = () => {
+  const handleClick = () => {
     if (openOnHoverProp) {
       dispatch({ type: 'SET_OPEN_ON_HOVER_BEHAVIOR', value: true })
     }
     dispatch({ type: 'CLOSE_MINICART' })
   }
-  const mouseLeaveHandler = () => {
+  const handleMouseLeave = () => {
     if (!openOnHoverBehavior) {
       return
     }
@@ -39,18 +39,18 @@ const PopupMode: FC = ({ children }) => {
   }
 
   return (
-    <div onMouseLeave={mouseLeaveHandler}>
+    <div onMouseLeave={handleMouseLeave}>
       <MinicartIconButton />
       {open && (
         <Overlay>
           {!openOnHoverBehavior && (
             <div
               className="fixed top-0 left-0 w-100 h-100"
-              onClick={clickHandler}
+              onClick={handleClick}
             />
           )}
           <div
-            className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-colunm`}
+            className={`${handles.popupWrapper} ${styles.popupBoxPosition} absolute z-max flex flex-column`}
           >
             <div
               className={`${handles.popupContentContainer} w-100 shadow-3 bg-base`}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve the current popup minicart behavior when `openOnHover` is set to `true`.

#### What problem is this solving?

This should make the minicart behave as described in: https://app.clubhouse.io/vtex/story/28421/minicart-on-hover-should-be-open-only-during-interaction

#### How should this be manually tested?

https://minicarthover--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
