### PR TITLE
Add new pixel event 'cartId'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `cartId` pixel event.
 
 ## [2.42.1] - 2020-01-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-
 - `cartId` pixel event.
 
 ## [2.42.1] - 2020-01-31

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -29,6 +29,7 @@ const CSS_HANDLES = [
   'minicartFooter',
 ] as const
 
+// eslint-disable-next-line react/display-name
 const MinicartHeader: FC<{ minicartTitleHandle: string }> = memo(
   ({ minicartTitleHandle }) => (
     <h3

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -1,12 +1,14 @@
 import React, { FC } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 import MinicartIconButton from './components/MinicartIconButton'
 import DrawerMode from './components/DrawerMode'
 
 import { MinicartContextProvider, useMinicartState } from './MinicartContext'
 import PopupMode from './components/Popup'
+import useCartIdPixel from './modules/useCartIdPixel'
 
 const CSS_HANDLES = ['minicartWrapperContainer', 'minicartContainer'] as const
 
@@ -52,11 +54,21 @@ const Minicart: FC<MinicartProps> = ({
   )
 }
 
+const CartIdPixel = () => {
+  const { orderForm, loading }: OrderFormContext = useOrderForm()
+
+  const orderFormId = !loading && orderForm ? orderForm.id : undefined
+  useCartIdPixel(orderFormId)
+
+  return null
+}
+
 const EnhancedMinicart = (props: MinicartProps) => (
   <MinicartContextProvider
     variation={props.variation}
     openOnHover={props.openOnHover}
   >
+    <CartIdPixel />
     <Minicart {...props} />
   </MinicartContextProvider>
 )

--- a/react/index.js
+++ b/react/index.js
@@ -23,7 +23,10 @@ import MiniCartContent from './legacy/components/MiniCartContent'
 import Sidebar from './legacy/components/Sidebar'
 import Popup from './legacy/components/Popup'
 import { shouldShowItem } from './legacy/utils/itemsHelper'
-import { mapBuyButtonItemToPixel, mapCartItemToPixel } from './modules/pixelHelper'
+import {
+  mapBuyButtonItemToPixel,
+  mapCartItemToPixel,
+} from './modules/pixelHelper'
 
 import fullMinicartQuery from './legacy/localState/graphql/fullMinicartQuery.gql'
 import updateItemsMutation from './legacy/localState/graphql/updateItemsMutation.gql'
@@ -35,6 +38,7 @@ import createLocalState, { ITEMS_STATUS } from './legacy/localState'
 
 import styles from './legacy/minicart.css'
 import useMarketingSessionParams from './legacy/hooks/useMarketingSessionParams'
+import useCardIdPixel from './modules/useCartIdPixel'
 
 const DEFAULT_LABEL_CLASSES = ''
 const DEFAULT_ICON_CLASSES = 'gray'
@@ -179,7 +183,10 @@ const MiniCart = ({
   }, [minicartState.orderForm])
 
   const orderForm = pathOr(localOrderForm, ['orderForm'], data)
-  const orderFormId = orderForm && orderForm.orderFormId
+  const orderFormId =
+    orderForm && orderForm.orderFormId ? orderForm.orderFormId : undefined
+
+  useCardIdPixel(orderFormId)
 
   const minicartItems = useMemo(() => {
     try {

--- a/react/modules/useCartIdPixel.tsx
+++ b/react/modules/useCartIdPixel.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
+
+const useCartIdPixel = (orderFormId?: string) => {
+  const { push } = usePixel()
+
+  useEffect(() => {
+    if (!orderFormId) {
+      return
+    }
+
+    push({
+      event: 'cartId',
+      cartId: orderFormId,
+    })
+  }, [push, orderFormId])
+}
+
+export default useCartIdPixel

--- a/react/typings/OrderForm.ts
+++ b/react/typings/OrderForm.ts
@@ -34,6 +34,7 @@ interface SKUSpecification {
 }
 
 interface OrderForm {
+  id: string
   items: OrderFormItem[]
   marketingData: MarketingData
   totalizers: Totalizer[]

--- a/react/typings/vtex.checkout-resources.d.ts
+++ b/react/typings/vtex.checkout-resources.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.checkout-resources/Utils'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible for a pixel to get the orderFormId.

#### What problem is this solving?

Development of a Salesforce pixel to abandoned cart.

#### How should this be manually tested?

New cart:
https://cartnew--storecomponents.myvtex.com/

Old cart:
https://cartlegacy--storecomponents.myvtex.com/

Check the `pixelManagerEvents` variable for the `cartId` event
![image](https://user-images.githubusercontent.com/284515/73569079-7afdaa00-4448-11ea-8739-5d0c7b178887.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
