### PR TITLE
Add all-contributors and codeowners

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,9 +1,14 @@
 {
+  "projectName": "minicart",
+  "projectOwner": "vtex-apps",
+  "repoType": "github",
+  "repoHost": "https://github.com",
   "files": [
-    "README.md"
+    "docs/README.md"
   ],
   "imageSize": 100,
   "commit": false,
+  "commitConvention": "none",
   "contributors": [
     {
       "login": "lucasayb",
@@ -15,9 +20,5 @@
       ]
     }
   ],
-  "contributorsPerLine": 7,
-  "projectName": "minicart",
-  "projectOwner": "vtex-apps",
-  "repoType": "github",
-  "repoHost": "https://github.com"
+  "contributorsPerLine": 7
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Updated `CODEOWNERS` file with responsible teams for each directory.
+- Updated `.all-contributorsrc`.
 
 ## [2.43.5] - 2020-02-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Updated `CODEOWNERS` file with responsible teams for each directory.
 
 ## [2.43.5] - 2020-02-18
 ### Changed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @vtex-apps/store-framework-devs
+docs/ @vtex-apps/technical-writers


### PR DESCRIPTION
This automated pull request aims to:

- Add `all-contributors` to the project.
- Add `CODEOWNERS` with mentions to the store-framework dev team and the tech-writers team for `docs` changes.