### PR TITLE
Add referenceId to pixel payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `referenceId` to `addToCart` and `cartChanged` pixel event payloads.
 
 ## [2.44.0] - 2020-03-11
 ### Added

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -12,6 +12,7 @@ export function mapCartItemToPixel(item: CartItem): PixelCartItem {
     imageUrl: item.imageUrls
       ? fixUrlProtocol(item.imageUrls.at3x)
       : item.imageUrl ?? '',
+    referenceId: item.refId,
   }
 }
 
@@ -31,6 +32,7 @@ export function mapBuyButtonItemToPixel(item: BuyButtonItem): PixelCartItem {
     category,
     detailUrl: item.detailUrl,
     imageUrl: item.imageUrl,
+    referenceId: item.refId,
   }
 }
 
@@ -83,6 +85,7 @@ interface PixelCartItem {
   category: string
   detailUrl: string
   imageUrl: string
+  referenceId: string
 }
 
 interface BuyButtonItem {
@@ -96,6 +99,7 @@ interface BuyButtonItem {
   category: string
   detailUrl: string
   imageUrl: string
+  refId: string
 }
 
 interface CartItem {
@@ -119,4 +123,5 @@ interface CartItem {
     at2x: string
     at3x: string
   }
+  refId: string
 }

--- a/react/typings/OrderForm.ts
+++ b/react/typings/OrderForm.ts
@@ -22,6 +22,7 @@ interface OrderFormItem {
   productCategories: Record<string, string>
   productCategoryIds: string
   productRefId: string
+  refId: string
 }
 
 interface ItemAdditionalInfo {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add (sku) `referenceId` to the 

Dependent of: 
- https://github.com/vtex/checkout-graphql/pull/57
- https://github.com/vtex-apps/checkout-resources/pull/41

Related to:
- https://app.clubhouse.io/vtex/story/33546/add-skurefid-to-pixel-cart-events
- https://github.com/vtex-apps/pixel-app-template/issues/7

#### What problem is this solving?

We weren't passing the reference id to pixel events.

#### How should this be manually tested?

1) Go to https://kiwi--storecomponents.myvtex.com/
2) Add the `tank top` to the cart
3) Open minicart
4) Change the quantity
5) Go to the dev tools and type `pixelManagerEvents`
6) Check the `items` prop of the two last entries for the `referenceId` property.

#### Screenshots or example usage

n/a

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
