### PR TITLE
Add prop to initialOpen option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `initialOpen` prop.
 
 ## [2.45.0] - 2020-03-25
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ The VTEX Minicart is a block that displays a summary list of all items added by 
 | `maxDrawerWidth`       | `Number`  | Maximum width (in pixels) for the `'sidebar'` Minicart when opened.                                                                                                                                                                             | `440`         |
 | `openOnHover`          | `Boolean` | Whether the `'popup'` minicart should open when the user hovers over it                                                                                                                                                                         | false         |
 | `quantityDisplay`      | `Enum`    | Shows the quantity badge even when the amount of products in the cart is zero  (values: `'always'` or `'not-empty'` or ` 'never'`)                                                                                                              | `'not-empty'` |
+| `initialOpen`          | `Boolean`  | Minicart starts open.                                                                                   | `false`         |
 
 ### Advanced Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ The VTEX Minicart is a block that displays a summary list of all items added by 
 | `maxDrawerWidth`       | `Number`  | Maximum width (in pixels) for the `'sidebar'` Minicart when opened.                                                                                                                                                                             | `440`         |
 | `openOnHover`          | `Boolean` | Whether the `'popup'` minicart should open when the user hovers over it                                                                                                                                                                         | false         |
 | `quantityDisplay`      | `Enum`    | Shows the quantity badge even when the amount of products in the cart is zero  (values: `'always'` or `'not-empty'` or ` 'never'`)                                                                                                              | `'not-empty'` |
-| `initialOpen`          | `Boolean`  | Minicart starts open.                                                                                   | `false`         |
+| `initialOpen`          | `Boolean`  | Whether the Minicart will be displayed already opened (`true`) or not (`false`) | `false`         |
 
 ### Advanced Configuration
 

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -17,6 +17,7 @@ const Minicart: FC<MinicartProps> = ({
   linkVariationUrl,
   children,
   quantityDisplay = 'not-empty',
+  initialOpen = false,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { variation } = useMinicartState()
@@ -46,6 +47,7 @@ const Minicart: FC<MinicartProps> = ({
             maxDrawerWidth={maxDrawerWidth}
             drawerSlideDirection={drawerSlideDirection}
             quantityDisplay={quantityDisplay}
+            initialOpen={initialOpen}
           >
             {children}
           </DrawerMode>

--- a/react/components/DrawerMode.tsx
+++ b/react/components/DrawerMode.tsx
@@ -11,6 +11,7 @@ interface Props {
   maxDrawerWidth: number | string
   drawerSlideDirection: SlideDirectionType
   quantityDisplay: 'always' | 'never' | 'not-empty'
+  initialOpen: boolean
 }
 
 const DrawerMode: FC<Props> = ({
@@ -18,6 +19,7 @@ const DrawerMode: FC<Props> = ({
   drawerSlideDirection,
   children,
   quantityDisplay,
+  initialOpen = false,
 }) => {
   const handles = useCssHandles(CSS_HANLDES)
   return (
@@ -25,6 +27,7 @@ const DrawerMode: FC<Props> = ({
       maxWidth={maxDrawerWidth}
       slideDirection={drawerSlideDirection}
       customIcon={<MinicartIconButton quantityDisplay={quantityDisplay} />}
+      initialOpen={initialOpen}
     >
       <div
         className={`${handles.minicartSideBarContentWrapper} w-100 h-100`}

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -1,6 +1,7 @@
 interface MinicartProps {
   variation: MinicartVariationType
   openOnHover: boolean
+  initialOpen: boolean
   linkVariationUrl: string
   maxDrawerWidth: number | string
   drawerSlideDirection: SlideDirectionType


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Allow to start open the component

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The customer needs the Mini Cart to start open. I created a PR in the Drawer repository with this prop too.

#### How should this be manually tested?
https://minicartopen--aldi.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
