### PR TITLE
Feature/icon minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `MinicartIcon` prop to `minicart.v2`.
 
 ## [2.49.0] - 2020-06-22
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,8 @@ The VTEX Minicart is a block that displays a summary list of all items added by 
 | `openOnHover`          | `boolean`                 | Whether the `popup` minicart should open when the user hovers over it.                                                                                                                                                                       | `false`         |
 | `quantityDisplay`      | `enum`                    | Shows the quantity badge even when the amount of products in the cart is zero. Possible values are: `always` or `not-empty` or `never`).                                                                                                                | `not-empty` |
 | `itemCountMode` | `enum` | Quantity badge behavior when displaying the number of total items added in Minicart. Possible values are: `total`  (quantity badge displays the number of items added to the cart) or `distinct` (quantity badge only displays the number of different products added to the cart). | `distinct` |
-| `backdropMode`         | `enum` | Controls whether the backdrop should be displayed when the `drawer` Minicart is opened or not. Possible values are: `visible` (rendering the backdrop) or `none` (rendering the `drawer` without backdrop).  | `none` |                                    
+| `backdropMode`         | `enum` | Controls whether the backdrop should be displayed when the `drawer` Minicart is opened or not. Possible values are: `visible` (rendering the backdrop) or `none` (rendering the `drawer` without backdrop).  | `none` |
+| `MinicartIcon` | `block` | Icon displayed in the Minicart button. This prop's value must match the name of the block responsible for rendering the desired icon. | `icon-cart` (from [Store Icons](https://vtex.io/docs/components/all/vtex.store-icons/) app) |
 
 ### Advanced Configuration
 
@@ -61,7 +62,15 @@ According to the `minicart.v2` composition, it can be highly customizable using 
 // This is the default blocks implementation for the minicart-layout
 {
   "minicart.v2": {
+    "props": {
+      "MinicartIcon": "icon-cart#minicart-icon"
+    },
     "children": ["minicart-base-content"]
+  },
+  "icon-cart#minicart-icon": {
+    "props": {
+      "size": 24
+    }
   },
   "minicart-base-content": {
     "blocks": ["minicart-empty-state"],

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -3,6 +3,7 @@ import { useCssHandles } from 'vtex.css-handles'
 import { BackdropMode } from 'vtex.store-drawer'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { MaybeResponsiveValue } from 'vtex.responsive-values'
+import { IconCart } from 'vtex.store-icons'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 
 import MinicartIconButton from './components/MinicartIconButton'
@@ -18,6 +19,7 @@ interface MinicartProps {
   openOnHover: boolean
   linkVariationUrl: string
   maxDrawerWidth: number | string
+  MinicartIcon: React.ComponentType
   drawerSlideDirection: SlideDirectionType
   quantityDisplay: MinicartIconButtonType
   itemCountMode: MinicartTotalItemsType
@@ -29,6 +31,7 @@ const Minicart: FC<MinicartProps> = ({
   backdropMode,
   linkVariationUrl,
   maxDrawerWidth = 400,
+  MinicartIcon = IconCart,
   quantityDisplay = 'not-empty',
   itemCountMode = 'distinct',
   drawerSlideDirection = 'rightToLeft',
@@ -45,8 +48,9 @@ const Minicart: FC<MinicartProps> = ({
         <div className={`${handles.minicartContainer} flex flex-column`}>
           <a href={linkVariationUrl || checkoutUrl}>
             <MinicartIconButton
-              quantityDisplay={quantityDisplay}
+              Icon={MinicartIcon}
               itemCountMode={itemCountMode}
+              quantityDisplay={quantityDisplay}
             />
           </a>
         </div>
@@ -61,18 +65,20 @@ const Minicart: FC<MinicartProps> = ({
       <div className={`${handles.minicartContainer} flex flex-column`}>
         {variation === 'drawer' ? (
           <DrawerMode
+            Icon={MinicartIcon}
             backdropMode={backdropMode}
-            maxDrawerWidth={maxDrawerWidth}
-            drawerSlideDirection={drawerSlideDirection}
-            quantityDisplay={quantityDisplay}
             itemCountMode={itemCountMode}
+            maxDrawerWidth={maxDrawerWidth}
+            quantityDisplay={quantityDisplay}
+            drawerSlideDirection={drawerSlideDirection}
           >
             {children}
           </DrawerMode>
         ) : (
           <PopupMode
-            quantityDisplay={quantityDisplay}
+            Icon={MinicartIcon}
             itemCountMode={itemCountMode}
+            quantityDisplay={quantityDisplay}
           >
             {children}
           </PopupMode>

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -21,7 +21,7 @@ interface MinicartProps {
   maxDrawerWidth: number | string
   MinicartIcon: React.ComponentType
   drawerSlideDirection: SlideDirectionType
-  quantityDisplay: MinicartIconButtonType
+  quantityDisplay: QuantityDisplayType
   itemCountMode: MinicartTotalItemsType
   backdropMode?: MaybeResponsiveValue<BackdropMode>
 }

--- a/react/components/DrawerMode.tsx
+++ b/react/components/DrawerMode.tsx
@@ -12,7 +12,7 @@ interface Props {
   Icon: React.ComponentType
   maxDrawerWidth: number | string
   drawerSlideDirection: SlideDirectionType
-  quantityDisplay: MinicartIconButtonType
+  quantityDisplay: QuantityDisplayType
   itemCountMode: MinicartTotalItemsType
   backdropMode?: MaybeResponsiveValue<BackdropMode>
 }

--- a/react/components/DrawerMode.tsx
+++ b/react/components/DrawerMode.tsx
@@ -9,6 +9,7 @@ const DRAWER_CLOSE_ICON_HEIGHT = 58
 const CSS_HANLDES = ['minicartSideBarContentWrapper']
 
 interface Props {
+  Icon: React.ComponentType
   maxDrawerWidth: number | string
   drawerSlideDirection: SlideDirectionType
   quantityDisplay: MinicartIconButtonType
@@ -17,6 +18,7 @@ interface Props {
 }
 
 const DrawerMode: FC<Props> = ({
+  Icon,
   children,
   maxDrawerWidth,
   quantityDisplay,
@@ -32,8 +34,9 @@ const DrawerMode: FC<Props> = ({
       slideDirection={drawerSlideDirection}
       customIcon={
         <MinicartIconButton
-          quantityDisplay={quantityDisplay}
+          Icon={Icon}
           itemCountMode={itemCountMode}
+          quantityDisplay={quantityDisplay}
         />
       }
     >

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -10,7 +10,7 @@ const CSS_HANDLES = ['minicartIconContainer', 'minicartQuantityBadge'] as const
 
 interface Props {
   Icon: React.ComponentType
-  quantityDisplay: MinicartIconButtonType
+  quantityDisplay: QuantityDisplayType
   itemCountMode: MinicartTotalItemsType
 }
 

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -1,6 +1,5 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { ButtonWithIcon } from 'vtex.styleguide'
-import { IconCart } from 'vtex.store-icons'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -9,7 +8,8 @@ import styles from '../styles.css'
 
 const CSS_HANDLES = ['minicartIconContainer', 'minicartQuantityBadge'] as const
 
-interface MinicartIconButtonProps {
+interface Props {
+  Icon: React.ComponentType
   quantityDisplay: MinicartIconButtonType
   itemCountMode: MinicartTotalItemsType
 }
@@ -17,10 +17,8 @@ interface MinicartIconButtonProps {
 const totalItemsSum = (arr: OrderFormItem[]) =>
   arr.reduce((sum: number, product: OrderFormItem) => sum + product.quantity, 0)
 
-const MinicartIconButton: FC<MinicartIconButtonProps> = ({
-  quantityDisplay,
-  itemCountMode,
-}) => {
+const MinicartIconButton: React.FC<Props> = props => {
+  const { Icon, itemCountMode, quantityDisplay } = props
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const handles = useCssHandles(CSS_HANDLES)
   const { open, openBehavior, openOnHoverProp } = useMinicartState()
@@ -58,7 +56,7 @@ const MinicartIconButton: FC<MinicartIconButtonProps> = ({
     <ButtonWithIcon
       icon={
         <span className={`${handles.minicartIconContainer} gray relative`}>
-          <IconCart />
+          <Icon />
           {showQuantityBadge && (
             <span
               style={{ userSelect: 'none' }}

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -15,7 +15,7 @@ const CSS_HANDLES = [
 
 interface Props {
   Icon: React.ComponentType
-  quantityDisplay: MinicartIconButtonType
+  quantityDisplay: QuantityDisplayType
   itemCountMode: MinicartTotalItemsType
 }
 const PopupMode: FC<Props> = props => {

--- a/react/components/Popup.tsx
+++ b/react/components/Popup.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { FC } from 'react'
 import { Overlay } from 'vtex.react-portal'
 import { useCssHandles } from 'vtex.css-handles'
@@ -16,15 +14,16 @@ const CSS_HANDLES = [
 ]
 
 interface Props {
+  Icon: React.ComponentType
   quantityDisplay: MinicartIconButtonType
   itemCountMode: MinicartTotalItemsType
 }
-
-const PopupMode: FC<Props> = ({ children, quantityDisplay, itemCountMode }) => {
+const PopupMode: FC<Props> = props => {
+  const { children, quantityDisplay, Icon, itemCountMode } = props
   const {
     open,
-    hasBeenOpened,
     openBehavior,
+    hasBeenOpened,
     openOnHoverProp,
   } = useMinicartState()
   const dispatch = useMinicartDispatch()
@@ -43,12 +42,14 @@ const PopupMode: FC<Props> = ({ children, quantityDisplay, itemCountMode }) => {
   return (
     <div onMouseLeave={openBehavior === 'hover' ? handleMouseLeave : undefined}>
       <MinicartIconButton
-        quantityDisplay={quantityDisplay}
+        Icon={Icon}
         itemCountMode={itemCountMode}
+        quantityDisplay={quantityDisplay}
       />
       {open && (
         <Overlay>
           {openBehavior === 'click' && (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
             <div
               className="fixed top-0 left-0 w-100 h-100"
               onClick={handleClick}

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -1,4 +1,4 @@
-type MinicartIconButtonType = 'always' | 'never' | 'not-empty'
+type QuantityDisplayType = 'always' | 'never' | 'not-empty'
 
 type MinicartTotalItemsType = 'total' | 'distinct'
 

--- a/react/typings/vtex.store-icons.ts
+++ b/react/typings/vtex.store-icons.ts
@@ -1,1 +1,0 @@
-declare module 'vtex.store-icons'


### PR DESCRIPTION
#### What problem is this solving?

Users can now pass any icon to the button and set any size that they want to the icon

#### How to test it?

1. [Workspace](https://minicarticon--storecomponents.myvtex.com/)

The code that I used to change the icon was the same that I added to the documentation

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![image](https://user-images.githubusercontent.com/8517023/85325960-d8030680-b4a2-11ea-9eba-1cd23b671ffa.png)


#### Describe alternatives you've considered, if any.

Creating a prop to only get the icons props and pass it down, but this way gives more versatility to the user