### PR TITLE
CHK-323: Add memo to update and remove items handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Memoize change and remove callbacks to avoid re-rendering product list items
+  unnecessarily.
 
 ## [2.51.0] - 2020-09-08
 ### Added

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useCallback } from 'react'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useOrderItems } from 'vtex.order-items/OrderItems'
 import { ExtensionPoint } from 'vtex.render-runtime'
@@ -21,30 +21,33 @@ const ProductList: FC<Props> = ({ renderAsChildren }) => {
   const { push } = usePixel()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const handleQuantityChange = (
-    uniqueId: string,
-    quantity: number,
-    item: OrderFormItem
-  ) => {
-    const adjustedItem = {
-      ...mapCartItemToPixel(item),
-      quantity,
-    }
+  const handleQuantityChange = useCallback(
+    (uniqueId: string, quantity: number, item: OrderFormItem) => {
+      const adjustedItem = {
+        ...mapCartItemToPixel(item),
+        quantity,
+      }
 
-    push({
-      event: 'addToCart',
-      items: [adjustedItem],
-    })
-    updateQuantity({ uniqueId, quantity })
-  }
-  const handleRemove = (uniqueId: string, item: OrderFormItem) => {
-    const adjustedItem = mapCartItemToPixel(item)
-    push({
-      event: 'removeFromCart',
-      items: [adjustedItem],
-    })
-    removeItem({ uniqueId })
-  }
+      push({
+        event: 'addToCart',
+        items: [adjustedItem],
+      })
+      updateQuantity({ uniqueId, quantity })
+    },
+    [push, updateQuantity]
+  )
+
+  const handleRemove = useCallback(
+    (uniqueId: string, item: OrderFormItem) => {
+      const adjustedItem = mapCartItemToPixel(item)
+      push({
+        event: 'removeFromCart',
+        items: [adjustedItem],
+      })
+      removeItem({ uniqueId })
+    },
+    [push, removeItem]
+  )
 
   return (
     <div


### PR DESCRIPTION
#### What problem is this solving?

Updates the handlers to update and remove the items to be memoized, in order to avoid unnecessary renders of product list items.

#### How to test it?

Same as vtex-apps/checkout-cart#61.

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A