### PR TITLE
Use navigate when redirecting to checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use navigate when redirecting to checkout
 
 ## [2.53.0] - 2020-10-06
+
 ### Fix
 - Mini cart not rendering variation link when in mobile version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.53.0] - 2020-10-06
 
+### Fixed
+- Use navigate when redirecting to checkout
+
+## [2.53.0] - 2020-10-06
 ### Fix
 - Mini cart not rendering variation link when in mobile version.
 

--- a/react/modules/checkoutHook.ts
+++ b/react/modules/checkoutHook.ts
@@ -3,13 +3,13 @@ import { useRuntime } from 'vtex.render-runtime'
 
 export default function useCheckout() {
   const { url: checkoutUrl, major } = useCheckoutURL()
-  const { navigate, rootPath = '' } = useRuntime()
+  const { navigate  } = useRuntime()
 
   const goToCheckout = (url: string) => {
     if (major > 0 && url === checkoutUrl) {
       navigate({ to: url })
     } else {
-      window.location.href = `${rootPath}${url}`
+      navigate({ to: url, fallbackToWindowLocation: true })
     }
   }
 

--- a/react/modules/checkoutHook.ts
+++ b/react/modules/checkoutHook.ts
@@ -7,7 +7,7 @@ export default function useCheckout() {
 
   const goToCheckout = (url: string) => {
     if (major > 0 && url === checkoutUrl) {
-      navigate({ to: url })
+      navigate({ to: url, fallbackToWindowLocation: false })
     } else {
       navigate({ to: url, fallbackToWindowLocation: true })
     }

--- a/react/modules/checkoutHook.ts
+++ b/react/modules/checkoutHook.ts
@@ -3,7 +3,7 @@ import { useRuntime } from 'vtex.render-runtime'
 
 export default function useCheckout() {
   const { url: checkoutUrl, major } = useCheckoutURL()
-  const { navigate  } = useRuntime()
+  const { navigate } = useRuntime()
 
   const goToCheckout = (url: string) => {
     if (major > 0 && url === checkoutUrl) {


### PR DESCRIPTION
#### What problem is this solving?

Use navigate when redirecting to checkout cart to permit adding the loading bar on top of the document.

#### How to test it?

In the workspace try to add to cart and verify if everything is ok( with the redirect) and if the document has a loading bar in the process.

https://vitorflg--storecomponents.myvtex.com/

[Workspace](Link goes here!)

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

https://github.com/vtex-apps/render-runtime/pull/567
