### PR TITLE
Fix/link mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- Mini cart not rendering variation link when in mobile version.
+
 ## [2.52.0] - 2020-10-05
 ### Added
 - Translations for `bg`, `ca`, `da`, `de`, `el`, `fi`, `fr`, `it`, `ko`, `nl`, `pl`, `ru`, `sk`, `sl`, `sv`, and `uk`.

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -45,9 +45,7 @@ const Minicart: FC<Partial<MinicartProps>> = ({
   const { variation } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
 
-  console.log(variation);
-
-  if (variation === 'link') {    
+  if (variation === 'link') {
     return (
       <aside
         className={`${handles.minicartWrapperContainer} relative fr flex items-center`}

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -45,7 +45,9 @@ const Minicart: FC<Partial<MinicartProps>> = ({
   const { variation } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
 
-  if (variation === 'link') {
+  console.log(variation);
+
+  if (variation === 'link') {    
     return (
       <aside
         className={`${handles.minicartWrapperContainer} relative fr flex items-center`}

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -65,7 +65,8 @@ const MinicartContextProvider: FC<Props> = ({
 
   // This prevents a popup minicart from being used on a mobile device
   const resolvedVariation =
-    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480)) ? 'drawer' : variation
+    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480)) 
+      ? 'drawer' : variation
 
   const [state, dispatch] = useReducer(minicartContextReducer, {
     variation: resolvedVariation,

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -65,8 +65,9 @@ const MinicartContextProvider: FC<Props> = ({
 
   // This prevents a popup minicart from being used on a mobile device
   const resolvedVariation =
-    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480)) 
-      ? 'drawer' : variation
+    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480))
+      ? 'drawer'
+      : variation
 
   const [state, dispatch] = useReducer(minicartContextReducer, {
     variation: resolvedVariation,

--- a/react/MinicartContext.tsx
+++ b/react/MinicartContext.tsx
@@ -65,7 +65,7 @@ const MinicartContextProvider: FC<Props> = ({
 
   // This prevents a popup minicart from being used on a mobile device
   const resolvedVariation =
-    isMobile || (window && window.innerWidth <= 480) ? 'drawer' : variation
+    variation === 'popup' && (isMobile || (window && window.innerWidth <= 480)) ? 'drawer' : variation
 
   const [state, dispatch] = useReducer(minicartContextReducer, {
     variation: resolvedVariation,


### PR DESCRIPTION
#### What problem is this solving?

In mobile version we were only permitting variation to be drawer to prevent popup, but link is also a possible variation on mobile

#### How to test it?

Resize your screen to mobile resolution, then click in minicart icon, if it redirects to another link, it's working

[Workspace](https://cartbug--motorolauk.myvtex.com/)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/dry9yDs7x8Jh1QAxHU/giphy.gif)
