### PR TITLE
Remove assembly options from items count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `distinctWithoutAssembliesAvailable`, `totalWithoutAssembliesAvailable`, `totalWithoutAssemblies` and `distinctWithoutAssemblies` values for `itemCountMode`.
+
 ## [2.54.1] - 2020-10-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 - Ignore assemblies values on `itemCountMode`.
 
 ## [2.54.1] - 2020-10-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `distinctWithoutAssembliesAvailable`, `totalWithoutAssembliesAvailable`, `totalWithoutAssemblies` and `distinctWithoutAssemblies` values for `itemCountMode`.
+- Ignore assemblies values on `itemCountMode`.
 
 ## [2.54.1] - 2020-10-20
 

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -16,13 +16,13 @@ interface Props {
 
 const countCartItems = (
   countMode: MinicartTotalItemsType,
-  arr: OrderFormItem[]
+  allItems: OrderFormItem[]
 ) => {
-  // Filter only main products - there is some items with '0' on parentItemIndex
-  arr = arr.filter(item => item.parentItemIndex === null)
+  // Filter only main products, remove assembly items from the count
+  const items = allItems.filter(item => item.parentItemIndex === null)
 
   if (countMode === 'distinctAvailable') {
-    return arr.reduce((itemQuantity: number, item) => {
+    return items.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + 1
       }
@@ -31,7 +31,7 @@ const countCartItems = (
   }
 
   if (countMode === 'totalAvailable') {
-    return arr.reduce((itemQuantity: number, item) => {
+    return items.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + item.quantity
       }
@@ -40,13 +40,13 @@ const countCartItems = (
   }
 
   if (countMode === 'total') {
-    return arr.reduce((itemQuantity: number, item) => {
+    return items.reduce((itemQuantity: number, item) => {
       return itemQuantity + item.quantity
     }, 0)
   }
 
   // countMode === 'distinct'
-  return arr.length
+  return items.length
 }
 
 const MinicartIconButton: React.FC<Props> = props => {

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -18,15 +18,10 @@ const countCartItems = (
   countMode: MinicartTotalItemsType,
   arr: OrderFormItem[]
 ) => {
-  if (countMode.indexOf('WithoutAssemblies') !== -1) {
-    // Filter only main products - there is some items with '0' on parentItemIndex
-    arr = arr.filter(item => item.parentItemIndex === null)
-  }
+  // Filter only main products - there is some items with '0' on parentItemIndex
+  arr = arr.filter(item => item.parentItemIndex === null)
 
-  if (
-    countMode === 'distinctAvailable' ||
-    countMode === 'distinctWithoutAssembliesAvailable'
-  ) {
+  if (countMode === 'distinctAvailable') {
     return arr.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + 1
@@ -35,10 +30,7 @@ const countCartItems = (
     }, 0)
   }
 
-  if (
-    countMode === 'totalAvailable' ||
-    countMode === 'totalWithoutAssembliesAvailable'
-  ) {
+  if (countMode === 'totalAvailable') {
     return arr.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + item.quantity
@@ -47,13 +39,13 @@ const countCartItems = (
     }, 0)
   }
 
-  if (countMode === 'total' || countMode === 'totalWithoutAssemblies') {
+  if (countMode === 'total') {
     return arr.reduce((itemQuantity: number, item) => {
       return itemQuantity + item.quantity
     }, 0)
   }
 
-  // countMode === 'distinct' || countMode === 'distinctWithoutAssemblies'
+  // countMode === 'distinct'
   return arr.length
 }
 

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -18,8 +18,16 @@ const countCartItems = (
   countMode: MinicartTotalItemsType,
   arr: OrderFormItem[]
 ) => {
-  if (countMode === 'distinctAvailable') {
-    return arr.reduce((itemQuantity: number, item: OrderFormItem) => {
+  if (countMode.indexOf('WithoutAssemblies') !== -1) {
+    // Filter only main products - there is some items with '0' on parentItemIndex
+    arr = arr.filter(item => item.parentItemIndex === null)
+  }
+
+  if (
+    countMode === 'distinctAvailable' ||
+    countMode === 'distinctWithoutAssembliesAvailable'
+  ) {
+    return arr.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + 1
       }
@@ -27,8 +35,11 @@ const countCartItems = (
     }, 0)
   }
 
-  if (countMode === 'totalAvailable') {
-    return arr.reduce((itemQuantity: number, item: OrderFormItem) => {
+  if (
+    countMode === 'totalAvailable' ||
+    countMode === 'totalWithoutAssembliesAvailable'
+  ) {
+    return arr.reduce((itemQuantity: number, item) => {
       if (item.availability === 'available') {
         return itemQuantity + item.quantity
       }
@@ -36,13 +47,13 @@ const countCartItems = (
     }, 0)
   }
 
-  if (countMode === 'total') {
-    return arr.reduce((itemQuantity: number, item: OrderFormItem) => {
+  if (countMode === 'total' || countMode === 'totalWithoutAssemblies') {
+    return arr.reduce((itemQuantity: number, item) => {
       return itemQuantity + item.quantity
     }, 0)
   }
 
-  // countMode === 'distinct'
+  // countMode === 'distinct' || countMode === 'distinctWithoutAssemblies'
   return arr.length
 }
 

--- a/react/typings/OrderForm.ts
+++ b/react/typings/OrderForm.ts
@@ -23,6 +23,7 @@ interface OrderFormItem {
   productCategoryIds: string
   productRefId: string
   refId: string
+  parentItemIndex: number | null
 }
 
 interface ItemAdditionalInfo {

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -5,6 +5,10 @@ type MinicartTotalItemsType =
   | 'distinct'
   | 'totalAvailable'
   | 'distinctAvailable'
+  | 'totalWithoutAssemblies'
+  | 'distinctWithoutAssemblies'
+  | 'totalWithoutAssembliesAvailable'
+  | 'distinctWithoutAssembliesAvailable'
 
 type SlideDirectionType =
   | 'horizontal'

--- a/react/typings/global.ts
+++ b/react/typings/global.ts
@@ -5,10 +5,6 @@ type MinicartTotalItemsType =
   | 'distinct'
   | 'totalAvailable'
   | 'distinctAvailable'
-  | 'totalWithoutAssemblies'
-  | 'distinctWithoutAssemblies'
-  | 'totalWithoutAssembliesAvailable'
-  | 'distinctWithoutAssembliesAvailable'
 
 type SlideDirectionType =
   | 'horizontal'


### PR DESCRIPTION
#### What problem is this solving?

With the Assembly Options customizating the minicart shows a lot of products and the assemblies aren't important to count.

#### How to test it?

You will need to fill the postal code form to procced to store, on the catalog you will be able to add and check the minicart quantity updated - only at `/catalog`

[Workspace](https://mcdon90--acctglobal.myvtex.com)

#### Screenshots or example usage:

**Before**
![image](https://user-images.githubusercontent.com/49173685/100889376-d0a24900-3495-11eb-9e70-326dd758cd39.png)

**After**
![image](https://user-images.githubusercontent.com/49173685/100889477-f0d20800-3495-11eb-87db-e6ed12bed53d.png)

#### Related to / Depends on

These two apps with this modifications are linked on workspace:

- https://github.com/vtex-apps/checkout-resources/pull/60
- https://github.com/vtex-apps/checkout-graphql/pull/105

#### How does this PR make you feel?

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media1.giphy.com/media/3ml6TOvA3YXJRFqDZl/giphy.gif)
