### PR TITLE
adicionando interface para botão fechar carrinho

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,14 @@ Therefore, in order to customize the Minicart configuration, you can simply copy
 
 For further information on how to configure each of the blocks used to compose `minicart.v2`, check out [Product List](https://vtex.io/docs/app/vtex.product-list) and [Checkout Summary](https://vtex.io/docs/app/vtex.checkout-summary).
 
+Another block not used in default implementation is `minicart-close-button`, this block can be used to render a custom close button when minicart is in popup mode.
+
+`minicart-close-button` props:
+| Prop name  | Type | Description | Default value |
+| ---------- | ---- | ----------- | ------------- |
+| `Icon` | `block` | Icon block to be showed | `undefined` |
+| `text` | `string` | Text to be showed | `undefined` |
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,7 @@ For further information on how to configure each of the blocks used to compose `
 Another block not used in default implementation is `minicart-close-button`, this block can be used to render a custom close button when minicart is in popup mode.
 
 `minicart-close-button` props:
+
 | Prop name  | Type | Description | Default value |
 | ---------- | ---- | ----------- | ------------- |
 | `Icon` | `block` | Icon block to be showed | `undefined` |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.60.0",
+  "version": "2.59.0",
   "builders": {
     "messages": "1.x",
     "store": "0.x",

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
     "vtex.checkout-resources": "0.x",
     "vtex.flex-layout": "0.x",
     "vtex.rich-text": "0.x",
-    "vtex.responsive-values": "0.x"
+    "vtex.responsive-values": "0.x",
+    "vtex.native-types": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "builders": {
     "messages": "1.x",
     "store": "0.x",

--- a/react/CloseButton.tsx
+++ b/react/CloseButton.tsx
@@ -27,7 +27,7 @@ const CloseButton: FC<CloseButtonProps> = props => {
   }
 
   return (
-    <div className={`${handles.closeIconContainer} `}>
+    <div className={handles.closeIconContainer}>
       <button
         className={`${handles.closeIconButton} bg-transparent pointer bg-transparent transparent bn pointer`}
         onClick={handleClick}

--- a/react/CloseButton.tsx
+++ b/react/CloseButton.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
+import { formatIOMessage } from 'vtex.native-types'
+import { useIntl } from 'react-intl'
 
 import { useMinicartDispatch } from './MinicartContext'
 
@@ -17,12 +19,13 @@ interface CloseButtonProps {
 const CloseButton: FC<CloseButtonProps> = props => {
   const { Icon, text } = props
   const dispatch = useMinicartDispatch()
-
+  const intl = useIntl()
   const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleClick = () => {
     dispatch({ type: 'CLOSE_MINICART' })
   }
+
   return (
     <div className={`${handles.closeIconContainer} `}>
       <button
@@ -30,7 +33,11 @@ const CloseButton: FC<CloseButtonProps> = props => {
         onClick={handleClick}
       >
         {Icon && <Icon />}
-        {text && <p className={`${handles.closeButtonText} `}>{text}</p>}
+        {text && (
+          <p className={`${handles.closeButtonText} `}>
+            {formatIOMessage({ id: text, intl })}
+          </p>
+        )}
       </button>
     </div>
   )

--- a/react/CloseButton.tsx
+++ b/react/CloseButton.tsx
@@ -1,0 +1,35 @@
+import React, {FC} from 'react';
+import { useMinicartDispatch } from './MinicartContext'
+import {useCssHandles} from "vtex.css-handles"
+
+const CSS_HANDLES = [
+  'closeIconContainer',
+  'closeIconButton',
+  "closeButtonText"
+] as const
+
+interface CloseButtonProps {
+  Icon: React.ComponentType,
+  text: string
+}
+
+const CloseButton: FC<CloseButtonProps> = (props) => {
+  const {Icon, text} = props
+  const dispatch = useMinicartDispatch()
+
+  const {handles} = useCssHandles(CSS_HANDLES)
+
+  const handleClick = () => {
+    dispatch({type: "CLOSE_MINICART"})
+  }
+  return (
+    <div className={`${handles.closeIconContainer} `}>
+      <button className={`${handles.closeIconButton} bg-transparent pointer bg-transparent transparent bn pointer`} onClick={handleClick}>
+       {Icon && (<Icon/> )}
+       {text && ( <p className={`${handles.closeButtonText} `}>{text}</p> )}
+      </button>
+    </div>
+  );
+}
+
+export default CloseButton;

--- a/react/CloseButton.tsx
+++ b/react/CloseButton.tsx
@@ -1,35 +1,39 @@
-import React, {FC} from 'react';
+import React, { FC } from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+
 import { useMinicartDispatch } from './MinicartContext'
-import {useCssHandles} from "vtex.css-handles"
 
 const CSS_HANDLES = [
   'closeIconContainer',
   'closeIconButton',
-  "closeButtonText"
+  'closeButtonText',
 ] as const
 
 interface CloseButtonProps {
-  Icon: React.ComponentType,
+  Icon: React.ComponentType
   text: string
 }
 
-const CloseButton: FC<CloseButtonProps> = (props) => {
-  const {Icon, text} = props
+const CloseButton: FC<CloseButtonProps> = props => {
+  const { Icon, text } = props
   const dispatch = useMinicartDispatch()
 
-  const {handles} = useCssHandles(CSS_HANDLES)
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleClick = () => {
-    dispatch({type: "CLOSE_MINICART"})
+    dispatch({ type: 'CLOSE_MINICART' })
   }
   return (
     <div className={`${handles.closeIconContainer} `}>
-      <button className={`${handles.closeIconButton} bg-transparent pointer bg-transparent transparent bn pointer`} onClick={handleClick}>
-       {Icon && (<Icon/> )}
-       {text && ( <p className={`${handles.closeButtonText} `}>{text}</p> )}
+      <button
+        className={`${handles.closeIconButton} bg-transparent pointer bg-transparent transparent bn pointer`}
+        onClick={handleClick}
+      >
+        {Icon && <Icon />}
+        {text && <p className={`${handles.closeButtonText} `}>{text}</p>}
       </button>
     </div>
-  );
+  )
 }
 
-export default CloseButton;
+export default CloseButton

--- a/react/package.json
+++ b/react/package.json
@@ -20,6 +20,7 @@
     "babel-eslint": "^10.1.0",
     "typescript": "3.9.7",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.40.0/public/@types/vtex.checkout-resources",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.checkout-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-summary@0.17.0/public/@types/vtex.checkout-summary",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5028,6 +5028,10 @@ verror@1.10.0:
   version "0.15.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout#1b3e061cec4711dea3a0b98ce3d0434fdcca890b"
 
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types":
+  version "0.7.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"
+
 "vtex.order-items@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-items@0.9.2/public/@types/vtex.order-items":
   version "0.9.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-items@0.9.2/public/@types/vtex.order-items#4e1081e1dc88a6997296b27721fc1049d409e508"

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -1,35 +1,57 @@
 // This is the default blocks implementation for the minicart-layout
 {
   "minicart.v2": {
-    "children": ["minicart-base-content"]
+    "children": [
+      "minicart-base-content"
+    ]
   },
   "minicart-base-content": {
-    "blocks": ["minicart-empty-state"],
-    "children": ["minicart-product-list", "flex-layout.row#minicart-footer"]
+    "blocks": [
+      "minicart-empty-state"
+    ],
+    "children": [
+      "minicart-product-list",
+      "flex-layout.row#minicart-footer"
+    ]
   },
   "flex-layout.row#minicart-footer": {
     "props": {
       "blockClass": "minicart-footer"
     },
-    "children": ["flex-layout.col#minicart-footer"]
+    "children": [
+      "flex-layout.col#minicart-footer"
+    ]
   },
   "flex-layout.col#minicart-footer": {
-    "children": ["minicart-summary", "minicart-checkout-button"]
+    "children": [
+      "minicart-summary",
+      "minicart-checkout-button"
+    ]
   },
   "minicart-product-list": {
-    "blocks": ["product-list#minicart"]
+    "blocks": [
+      "product-list#minicart"
+    ]
   },
   "product-list#minicart": {
-    "blocks": ["product-list-content-mobile"]
+    "blocks": [
+      "product-list-content-mobile"
+    ]
   },
   "minicart-summary": {
-    "blocks": ["checkout-summary.compact#minicart"]
+    "blocks": [
+      "checkout-summary.compact#minicart"
+    ]
   },
-
   "checkout-summary.compact#minicart": {
-    "children": ["summary-totalizers#minicart"],
+    "children": [
+      "summary-totalizers#minicart"
+    ],
     "props": {
-      "totalizersToShow": ["Items", "Discounts"]
+      "totalizersToShow": [
+        "Items",
+        "Discounts"
+      ]
     }
   },
   "summary-totalizers#minicart": {
@@ -39,10 +61,14 @@
     }
   },
   "minicart-empty-state": {
-    "children": ["flex-layout.row#empty-state"]
+    "children": [
+      "flex-layout.row#empty-state"
+    ]
   },
   "flex-layout.row#empty-state": {
-    "children": ["flex-layout.col#empty-state"]
+    "children": [
+      "flex-layout.col#empty-state"
+    ]
   },
   "flex-layout.col#empty-state": {
     "children": [
@@ -64,6 +90,11 @@
   "rich-text#minicart-default-empty-state": {
     "props": {
       "text": "Your cart is empty."
+    }
+  },
+  "minicart-close-button": {
+    "props": {
+      "Icon": "icon-close"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,9 @@
 {
   "minicart": {
-    "allowed": ["sandbox", "product-summary"],
+    "allowed": [
+      "sandbox",
+      "product-summary"
+    ],
     "component": "index"
   },
   "minicart.v2": {
@@ -19,19 +22,26 @@
   },
   "minicart-product-list": {
     "component": "ProductList",
-    "allowed": ["product-list"]
+    "allowed": [
+      "product-list"
+    ]
   },
   "minicart-checkout-button": {
     "component": "CheckoutButton"
   },
   "minicart-summary": {
     "component": "Summary",
-    "allowed": ["checkout-summary"],
+    "allowed": [
+      "checkout-summary"
+    ],
     "render": "lazy"
   },
   "minicart-empty-state": {
     "component": "EmptyState",
     "composition": "children",
     "render": "lazy"
+  },
+  "minicart-close-button": {
+    "component": "CloseButton"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

this change allows to import close button and use they in another parts of minicart

#### How to test it?

In your theme store add the block `minicart-close-button`, you can pass an custom icon or a text or both to display.

[Workspace](https://luis--iaqua.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

![image](https://user-images.githubusercontent.com/48053804/116265130-3f3bb800-a751-11eb-8acf-87b9b6ec5093.png)


#### Describe alternatives you've considered, if any.

an alternative is add a customPixelEvent to closeMinicart

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/w4CIKkZDQWIoWLsxKZ/giphy.gif)
