### PR TITLE
Quantity badge interface

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "vendor": "vtex",
   "name": "minicart",
   "title": "Mini Cart",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "builders": {
     "messages": "1.x",
     "store": "0.x",

--- a/react/CloseButton.tsx
+++ b/react/CloseButton.tsx
@@ -1,0 +1,35 @@
+import React, {FC} from 'react';
+import { useMinicartDispatch } from './MinicartContext'
+import {useCssHandles} from "vtex.css-handles"
+
+const CSS_HANDLES = [
+  'closeIconContainer',
+  'closeIconButton',
+  "closeButtonText"
+] as const
+
+interface CloseButtonProps {
+  Icon: React.ComponentType,
+  text: string
+}
+
+const CloseButton: FC<CloseButtonProps> = (props) => {
+  const {Icon, text} = props
+  const dispatch = useMinicartDispatch()
+
+  const {handles} = useCssHandles(CSS_HANDLES)
+
+  const handleClick = () => {
+    dispatch({type: "CLOSE_MINICART"})
+  }
+  return (
+    <div className={`${handles.closeIconContainer} `}>
+      <button className={`${handles.closeIconButton} bg-transparent pointer bg-transparent transparent bn pointer`} onClick={handleClick}>
+       {Icon && (<Icon/> )}
+       {text && ( <p className={`${handles.closeButtonText} `}>{text}</p> )}
+      </button>
+    </div>
+  );
+}
+
+export default CloseButton;

--- a/react/QuantityBadge.tsx
+++ b/react/QuantityBadge.tsx
@@ -1,0 +1,3 @@
+import QuantityBadge from './components/QuantityBadge'
+
+export default QuantityBadge;

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { ButtonWithIcon } from 'vtex.styleguide'
-import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
-import styles from '../styles.css'
 import { useMinicartCssHandles } from './CssHandlesContext'
 import { useMinicartDispatch, useMinicartState } from '../MinicartContext'
+import QuantityBadge from './QuantityBadge'
 
 export const CSS_HANDLES = [
   'minicartIconContainer',
@@ -17,49 +16,11 @@ interface Props {
   itemCountMode: MinicartTotalItemsType
 }
 
-const countCartItems = (
-  countMode: MinicartTotalItemsType,
-  allItems: OrderFormItem[]
-) => {
-  // Filter only main products, remove assembly items from the count
-  const items = allItems.filter(item => item.parentItemIndex === null)
-
-  if (countMode === 'distinctAvailable') {
-    return items.reduce((itemQuantity: number, item) => {
-      if (item.availability === 'available') {
-        return itemQuantity + 1
-      }
-      return itemQuantity
-    }, 0)
-  }
-
-  if (countMode === 'totalAvailable') {
-    return items.reduce((itemQuantity: number, item) => {
-      if (item.availability === 'available') {
-        return itemQuantity + item.quantity
-      }
-      return itemQuantity
-    }, 0)
-  }
-
-  if (countMode === 'total') {
-    return items.reduce((itemQuantity: number, item) => {
-      return itemQuantity + item.quantity
-    }, 0)
-  }
-
-  // countMode === 'distinct'
-  return items.length
-}
-
 const MinicartIconButton: React.FC<Props> = props => {
   const { Icon, itemCountMode, quantityDisplay } = props
-  const { orderForm, loading }: OrderFormContext = useOrderForm()
   const { handles } = useMinicartCssHandles()
   const { open, openBehavior, openOnHoverProp } = useMinicartState()
   const dispatch = useMinicartDispatch()
-  const quantity = countCartItems(itemCountMode, orderForm.items)
-  const itemQuantity = loading ? 0 : quantity
 
   const handleClick = () => {
     if (openOnHoverProp) {
@@ -84,23 +45,14 @@ const MinicartIconButton: React.FC<Props> = props => {
     dispatch({ type: open ? 'CLOSE_MINICART' : 'OPEN_MINICART' })
   }
 
-  const showQuantityBadge =
-    (itemQuantity > 0 && quantityDisplay === 'not-empty') ||
-    quantityDisplay === 'always'
+  
 
   return (
     <ButtonWithIcon
       icon={
         <span className={`${handles.minicartIconContainer} gray relative`}>
           <Icon />
-          {showQuantityBadge && (
-            <span
-              style={{ userSelect: 'none' }}
-              className={`${handles.minicartQuantityBadge} ${styles.minicartQuantityBadgeDefault} c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
-            >
-              {itemQuantity}
-            </span>
-          )}
+          <QuantityBadge itemCountMode={itemCountMode} quantityDisplay={quantityDisplay}/>
         </span>
       }
       variation="tertiary"

--- a/react/components/QuantityBadge.tsx
+++ b/react/components/QuantityBadge.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import { useMinicartCssHandles } from './CssHandlesContext'
+import styles from '../styles.css'
+
+const countCartItems = (
+  countMode: MinicartTotalItemsType,
+  allItems: OrderFormItem[]
+) => {
+  // Filter only main products, remove assembly items from the count
+  const items = allItems.filter(item => item.parentItemIndex === null)
+
+  if (countMode === 'distinctAvailable') {
+    return items.reduce((itemQuantity: number, item) => {
+      if (item.availability === 'available') {
+        return itemQuantity + 1
+      }
+      return itemQuantity
+    }, 0)
+  }
+
+  if (countMode === 'totalAvailable') {
+    return items.reduce((itemQuantity: number, item) => {
+      if (item.availability === 'available') {
+        return itemQuantity + item.quantity
+      }
+      return itemQuantity
+    }, 0)
+  }
+
+  if (countMode === 'total') {
+    return items.reduce((itemQuantity: number, item) => {
+      return itemQuantity + item.quantity
+    }, 0)
+  }
+
+  // countMode === 'distinct'
+  return items.length
+}
+
+interface Props {
+  itemCountMode: MinicartTotalItemsType
+  quantityDisplay: QuantityDisplayType
+}
+
+
+const QuantityBadge: React.FC<Props> = props => { 
+  const {itemCountMode, quantityDisplay } = props
+  const { orderForm, loading }: OrderFormContext = useOrderForm()
+  const quantity = countCartItems(itemCountMode, orderForm.items)
+  const { handles } = useMinicartCssHandles()
+  const itemQuantity = loading ? 0 : quantity
+
+  const showQuantityBadge =
+    (itemQuantity > 0 && quantityDisplay === 'not-empty') ||
+    quantityDisplay === 'always'
+
+  return (
+    <>
+      {showQuantityBadge && (
+        <span
+          style={{ userSelect: 'none' }}
+          className={`${handles.minicartQuantityBadge} ${styles.minicartQuantityBadgeDefault} c-on-emphasis absolute t-mini bg-emphasis br4 w1 h1 pa1 flex justify-center items-center lh-solid`}
+        >
+          {itemQuantity}
+        </span>
+      )}
+    </>
+  );
+}
+
+export default QuantityBadge;

--- a/react/components/QuantityBadge.tsx
+++ b/react/components/QuantityBadge.tsx
@@ -45,15 +45,15 @@ interface Props {
 
 
 const QuantityBadge: React.FC<Props> = props => { 
-  const {itemCountMode, quantityDisplay } = props
+  const { itemCountMode, quantityDisplay = 'not-empty' } = props
   const { orderForm, loading }: OrderFormContext = useOrderForm()
   const quantity = countCartItems(itemCountMode, orderForm.items)
   const { handles } = useMinicartCssHandles()
   const itemQuantity = loading ? 0 : quantity
 
   const showQuantityBadge =
-    (itemQuantity > 0 && quantityDisplay === 'not-empty') ||
-    quantityDisplay === 'always'
+  (itemQuantity > 0 && quantityDisplay === 'not-empty') ||
+  quantityDisplay === 'always'
 
   return (
     <>

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -1,35 +1,57 @@
 // This is the default blocks implementation for the minicart-layout
 {
   "minicart.v2": {
-    "children": ["minicart-base-content"]
+    "children": [
+      "minicart-base-content"
+    ]
   },
   "minicart-base-content": {
-    "blocks": ["minicart-empty-state"],
-    "children": ["minicart-product-list", "flex-layout.row#minicart-footer"]
+    "blocks": [
+      "minicart-empty-state"
+    ],
+    "children": [
+      "minicart-product-list",
+      "flex-layout.row#minicart-footer"
+    ]
   },
   "flex-layout.row#minicart-footer": {
     "props": {
       "blockClass": "minicart-footer"
     },
-    "children": ["flex-layout.col#minicart-footer"]
+    "children": [
+      "flex-layout.col#minicart-footer"
+    ]
   },
   "flex-layout.col#minicart-footer": {
-    "children": ["minicart-summary", "minicart-checkout-button"]
+    "children": [
+      "minicart-summary",
+      "minicart-checkout-button"
+    ]
   },
   "minicart-product-list": {
-    "blocks": ["product-list#minicart"]
+    "blocks": [
+      "product-list#minicart"
+    ]
   },
   "product-list#minicart": {
-    "blocks": ["product-list-content-mobile"]
+    "blocks": [
+      "product-list-content-mobile"
+    ]
   },
   "minicart-summary": {
-    "blocks": ["checkout-summary.compact#minicart"]
+    "blocks": [
+      "checkout-summary.compact#minicart"
+    ]
   },
-
   "checkout-summary.compact#minicart": {
-    "children": ["summary-totalizers#minicart"],
+    "children": [
+      "summary-totalizers#minicart"
+    ],
     "props": {
-      "totalizersToShow": ["Items", "Discounts"]
+      "totalizersToShow": [
+        "Items",
+        "Discounts"
+      ]
     }
   },
   "summary-totalizers#minicart": {
@@ -39,10 +61,14 @@
     }
   },
   "minicart-empty-state": {
-    "children": ["flex-layout.row#empty-state"]
+    "children": [
+      "flex-layout.row#empty-state"
+    ]
   },
   "flex-layout.row#empty-state": {
-    "children": ["flex-layout.col#empty-state"]
+    "children": [
+      "flex-layout.col#empty-state"
+    ]
   },
   "flex-layout.col#empty-state": {
     "children": [
@@ -64,6 +90,11 @@
   "rich-text#minicart-default-empty-state": {
     "props": {
       "text": "Your cart is empty."
+    }
+  },
+  "minicart-close-button": {
+    "props": {
+      "Icon": "icon-close"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,9 @@
 {
   "minicart": {
-    "allowed": ["sandbox", "product-summary"],
+    "allowed": [
+      "sandbox",
+      "product-summary"
+    ],
     "component": "index"
   },
   "minicart.v2": {
@@ -19,19 +22,26 @@
   },
   "minicart-product-list": {
     "component": "ProductList",
-    "allowed": ["product-list"]
+    "allowed": [
+      "product-list"
+    ]
   },
   "minicart-checkout-button": {
     "component": "CheckoutButton"
   },
   "minicart-summary": {
     "component": "Summary",
-    "allowed": ["checkout-summary"],
+    "allowed": [
+      "checkout-summary"
+    ],
     "render": "lazy"
   },
   "minicart-empty-state": {
     "component": "EmptyState",
     "composition": "children",
     "render": "lazy"
+  },
+  "minicart-close-button": {
+    "component": "CloseButton"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -43,5 +43,8 @@
   },
   "minicart-close-button": {
     "component": "CloseButton"
+  },
+  "minicart-quantity-badge": {
+    "component": "QuantityBadge"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This change allows devs to import quantity badge and use in another parts of his minicart 

#### How to test it?

Import "minicart-quantity-badge" in your theme store and put in some part of minicart and the count will be displayed

[Workspace](https://luis--iaqua.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/48053804/116731835-9b584380-a9c0-11eb-9998-de27bb60bd8b.png)

#### Describe alternatives you've considered, if any.

Allows customize minicart header and the count display can passed as a prop to minicart-title
