### PR TITLE
Fixing GTM events to follow Google's defined patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- GTM events to follow Google's defined patterns
 
 ## [2.59.0] - 2021-04-22
 ### Added

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -28,15 +28,34 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
 
   const handleQuantityChange = useCallback(
     (uniqueId: string, quantity: number, item: OrderFormItem) => {
-      const adjustedItem = {
-        ...mapCartItemToPixel(item),
-        quantity,
+      if (quantity === item.quantity) {
+        return
       }
 
-      push({
-        event: 'addToCart',
-        items: [adjustedItem],
-      })
+      const quantityIncreased = quantity > item.quantity
+
+      if (quantityIncreased) {
+        const adjustedItem = {
+          ...mapCartItemToPixel(item),
+          quantity: quantity - item.quantity,
+        }
+
+        push({
+          event: 'addToCart',
+          items: [adjustedItem],
+        })
+      } else {
+        const adjustedItem = {
+          ...mapCartItemToPixel(item),
+          quantity: item.quantity - quantity,
+        }
+
+        push({
+          event: 'removeFromCart',
+          items: [adjustedItem],
+        })
+      }
+
       updateQuantity({ uniqueId, quantity }, options)
     },
     [push, updateQuantity]


### PR DESCRIPTION
#### What problem is this solving?

This PR makes the GTM events consistent when users change the product quantity. It now sends `removeFromCart` and `addToCart` events with `quantity` that reflects the difference between the previous and new quantities.

#### How to test it?

[Workspace](https://icarogtmprod--storecomponents.myvtex.com/)

#### Related to / Depends on

Related to [https://github.com/vtex-apps/google-tag-manager/pull/51](https://github.com/vtex-apps/google-tag-manager/pull/51)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/bcbPzkSCytDH2/giphy.gif)
