### PR TITLE
Feature/summary-installments block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pass paymentData as prop to Summary component
 
 ## [2.59.1] - 2021-06-08
 ### Fixed

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const Summary: FC<Props> = ({ classes }) => {
   const {
-    orderForm: { totalizers, value, paymentData},
+    orderForm: { totalizers, value, paymentData },
   } = useOrderForm()
 
   const { handles } = useCssHandles(CSS_HANDLES, { classes })

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const Summary: FC<Props> = ({ classes }) => {
   const {
-    orderForm: { totalizers, value },
+    orderForm: { totalizers, value, paymentData},
   } = useOrderForm()
 
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
@@ -21,6 +21,7 @@ const Summary: FC<Props> = ({ classes }) => {
       <ExtensionPoint
         id="checkout-summary"
         totalizers={totalizers}
+        paymentData={paymentData}
         total={value}
       />
     </div>


### PR DESCRIPTION
#### What problem is this solving?

Passing paymentData as prop to Summary component to allow showing installments related information inside checkout-summary app.

#### How to test it?

Go to [Workspace](https://installmentsminicart--tokstokio.myvtex.com/), add a product to cart and hover over minicart icon. Inspect SummaryContextProvider element with React DevTools to confirm paymentData being passed as prop.



#### Screenshots or example usage:

![](https://user-images.githubusercontent.com/34974565/100485803-3d0cf900-30e0-11eb-99f7-21968780848a.png)


