### PR TITLE
fix: last letter removed when itemname = skuname duo slice and leadingspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New condition in `getNameWithoutVariant` at `pixelHelper.ts` to check if item.name is the same as item.skuName.
 
 ## [2.61.0] - 2021-09-06
 ### Added

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -55,9 +55,10 @@ function fixUrlProtocol(url: string) {
 /**
  * Remove the variant from the end of the name.
  * Ex: from "Classic Shoes Pink" to "Classic Shoes"
+ * Ps: Some products has the name of the variation the same as the item
  */
 function getNameWithoutVariant(item: CartItem) {
-  if (!item.name.includes(item.skuName)) {
+  if (!item.name.includes(item.skuName) || item.name === item.skuName) {
     return item.name
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Some products might have their name equals to the name of its variations, this was causing a strange behavior that the last letter of the product was being removed, this was duo how getNameWithoutVariant was defined, needed to add the condition that if the name of the product is the same of the variation, we should return the name of the product

![image](https://user-images.githubusercontent.com/13649073/133142374-fff5c495-888b-479b-a8c1-c73c27442bc9.png)


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Check the events being triggered in dataLayer, specially the ones related to cart (add, remove)
https://www.loom.com/share/83f2e51d586e4615b10cb05c84ac859f

[Before](https://master--diageo.myvtex.com/)
![image](https://user-images.githubusercontent.com/13649073/133142347-3f5ef34b-6411-4fa6-9cd8-cc3f8a160ce4.png)



[After](https://iespinoza--diageo.myvtex.com/)
![image](https://user-images.githubusercontent.com/13649073/133143286-8ed9ecdf-cfa5-4eb8-91b7-6e333302820c.png)


#### Related to / Depends on

<!--- Optional -->

Zendesk #422404

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/1jajMAVf2vN9KxoFfw/giphy.gif?cid=ecf05e47njn3y2ect4pz7nbmlarbxq8cbvlesjkwwiz3m12x&rid=giphy.gif&ct=g)
