### PR TITLE
Adobe launch implementation, click gotToCheckout button

### DIFF
--- a/react/CheckoutButton.tsx
+++ b/react/CheckoutButton.tsx
@@ -3,9 +3,10 @@ import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 import { CssHandlesTypes, useCssHandles } from 'vtex.css-handles'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
-
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import { mapCartItemToPixel } from './modules/pixelHelper'
+import { usePixel } from 'vtex.pixel-manager'
 import useCheckout from './modules/checkoutHook'
-
 const CSS_HANDLES = ['minicartCheckoutButton'] as const
 
 interface Props {
@@ -16,13 +17,31 @@ interface Props {
 const CheckoutButton: FC<Props> = ({ finishShoppingButtonLink, classes }) => {
   const { url: checkoutUrl } = useCheckoutURL()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { orderForm }: OrderFormContext = useOrderForm()
+  const { push } = usePixel()
+
   const goToCheckout = useCheckout()
+
+  const emitEventAdobeLaunch = () => {   
+    if(orderForm.items?.length > 0){
+      const data = orderForm.items.map(mapCartItemToPixel)
+      push({
+        event: "cart",
+        items: data
+      })
+    }
+  }
+
+  const handleClick = () => {
+    emitEventAdobeLaunch()
+    goToCheckout(finishShoppingButtonLink || checkoutUrl)
+  }
 
   return (
     <div className={`${handles.minicartCheckoutButton} mv3 ph4 ph6-l`}>
       <Button
         id="proceed-to-checkout"
-        onClick={() => goToCheckout(finishShoppingButtonLink || checkoutUrl)}
+        onClick={handleClick}
         variation="primary"
         block
       >


### PR DESCRIPTION
#### What problem is this solving?

There was a need to implement Action Tracking in the gotToCart button in the store's minicart. This sends the event to Adobe Launch with cart data.

#### How to test it?

1 - Install the extension on Chrome "Adobe Experience Platform Debugger".
2 - After opening the extension, click on the "Network" menu.
3 - Open WorkSpace, go to the minicart and click on the "Go to Cart" button.

WorkSpace - https://minicart3900--samsungbr.myvtex.com/

![image](https://user-images.githubusercontent.com/40249259/136093851-3ded2891-d53c-4326-b618-43f2169fd3b2.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)


![](https://media.giphy.com/media/PQ0VI3S5vqL5pwQQJX/giphy.gif)
