### PR TITLE
WISHLIST-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Bug Fixed on pixelHelper if validation.
+
 ## [2.62.1] - 2021-11-17
 
 ## [2.62.0] - 2021-09-23

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -58,7 +58,10 @@ function fixUrlProtocol(url: string) {
  * Ps: Some products has the name of the variation the same as the item
  */
 function getNameWithoutVariant(item: CartItem) {
-  if (!item.name.includes(item.skuName) || item.name === item.skuName) {
+  if (
+    (item?.name && !item.name.includes(item.skuName)) ||
+    item.name === item.skuName
+  ) {
     return item.name
   }
 


### PR DESCRIPTION
Bug Fixed on pixelHelper if validation.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

It was reported a bug at first would be on wishlist app, however, we found a tiny bug on minicart.

Ticket: [https://vtex-dev.atlassian.net/browse/WISHLIST-31](https://vtex-dev.atlassian.net/browse/WISHLIST-31)

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

**Problem:**
1) To reproduce the problem, upon accessing the page https://lojamars.myvtex.com/ and login with a account, you have to create a wishlist, clicking in the star below "add to cart". 
2) If it's the first time, it'll request to create a list by inputing a name for it.
3) After creating a list and adding some products to it, add this products to the cart, and access the wishlist. 
4) Then exclude all the products from the cart, and add them again, but this time, directly from the Wishlist. By doing this, the header in the page disappear  

Store with the bug: [https://lojamars.myvtex.com/](https://lojamars.myvtex.com/)

**Solution**
...
4) It's working properly

**Workspace fixed:** 
[https://artur--lojamars.myvtex.com/](https://artur--lojamars.myvtex.com/)
