### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Prop `finishShoppingButtonLink` of `minicart-checkout-button`. 
 ## [2.63.0] - 2022-02-08
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-:information_source: **Minicart v1 block has been deprecated in favor of Minicart v2** which can be customized using the blocks defined by [Product List](https://vtex.io/docs/app/vtex.product-list) and [Checkout Summary](https://vtex.io/docs/app/vtex.checkout-summary). If you’re still using the former version, you can find its documentation here: [Minicart v1 documentation](https://github.com/vtex-apps/minicart/blob/383d7bbd3295f06d1b5854a0add561a872e1515c/docs/README.md)
+> ⚠️
+> 
+>   **Minicart v1 block has been deprecated in favor of Minicart v2** which can be customized using the blocks defined by [Product List](https://vtex.io/docs/app/vtex.product-list) and [Checkout Summary](https://vtex.io/docs/app/vtex.checkout-summary). If you’re still using the former version, you can find its documentation here: [Minicart v1 documentation](https://github.com/vtex-apps/minicart/blob/383d7bbd3295f06d1b5854a0add561a872e1515c/docs/README.md)
 
 The VTEX Minicart is a block that displays a summary list of all items added by customers in their shopping cart. Its data is fetched from the Checkout OrderForm API.
 
@@ -97,6 +99,14 @@ According to the `minicart.v2` composition, it can be highly customizable using 
   "minicart-summary": {
     "blocks": ["checkout-summary.compact#minicart"]
   },
+  
+  {
+  "minicart-checkout-button": {
+    "props": {
+      "finishShoppingButtonLink": "/checkout/#/orderform"
+    }
+  }
+},
 
   "checkout-summary.compact#minicart": {
     "children": ["summary-totalizers#minicart"],


### PR DESCRIPTION
#### What problem is this solving?

Fixed:
First warning callout

Added:
Prop `finishShoppingButtonLink` of `minicart-checkout-button`. The prop is listed in `flex-layout.col#minicart-footer`, but it is not declared.