### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Brackets in `minicart-checkout-button` (documentation).
 
 ## [2.63.2] - 2022-02-17
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,9 @@ The VTEX Minicart is a block that displays a summary list of all items added by 
  },
 ```
 
-:warning: **The Minicart v2 will only effectively function if the store uses the** [**Add To Cart Button**](https://vtex.io/docs/components/content-blocks/vtex.add-to-cart-button/) **instead of the** [**Buy Button**](https://vtex.io/docs/components/content-blocks/vtex.store-components/buybutton/) in blocks such as the Shelf and the Product Details Page. This is because Minicart v2 was built based on an indirect dependency with the Add To Cart button. That means that any other shopping buttons, as the Buy Button, are unable to render Minicart v2, even if it was correctly configured in the code. `
+> ⚠️
+> 
+>   **The Minicart v2 will only effectively function if the store uses the** [**Add To Cart Button**](https://vtex.io/docs/components/content-blocks/vtex.add-to-cart-button/) **instead of the** [**Buy Button**](https://vtex.io/docs/components/content-blocks/vtex.store-components/buybutton/) in blocks such as the Shelf and the Product Details Page. This is because Minicart v2 was built based on an indirect dependency with the Add To Cart button. That means that any other shopping buttons, as the Buy Button, are unable to render Minicart v2, even if it was correctly configured in the code. `
 
 | Prop name              | Type                      | Description                                                                                                                                                                                                                                     | Default value |
 | ---------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
@@ -99,12 +101,9 @@ According to the `minicart.v2` composition, it can be highly customizable using 
   "minicart-summary": {
     "blocks": ["checkout-summary.compact#minicart"]
   },
-  
-  {
   "minicart-checkout-button": {
     "props": {
       "finishShoppingButtonLink": "/checkout/#/orderform"
-    }
   }
 },
 


### PR DESCRIPTION
#### What problem is this solving?
There were too many brackets in the `mini-checkout-button`. This PR fixes this issue.