### PR TITLE
[USAAPPTEAM-623] Eliminate duplicate pixel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not emit `cartChanged` pixel event if orderForm is still updating (denoted by the most recent item's `additionalInfo` property being `undefined`)
+
 ## [2.63.3] - 2022-03-03
 ### Fixed
 - Brackets in `minicart-checkout-button` (documentation).

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -63,6 +63,8 @@ const Content: FC<Props> = ({
       return
     }
 
+    // if additionalInfo is undefined for the most recent item, orderForm is still updating
+    // and therefore we should not emit the pixel event yet
     if (
       orderForm.items.length > 0 &&
       orderForm.items[orderForm.items.length - 1].additionalInfo === undefined

--- a/react/BaseContent.tsx
+++ b/react/BaseContent.tsx
@@ -63,6 +63,13 @@ const Content: FC<Props> = ({
       return
     }
 
+    if (
+      orderForm.items.length > 0 &&
+      orderForm.items[orderForm.items.length - 1].additionalInfo === undefined
+    ) {
+      return
+    }
+
     push({
       event: 'cartChanged',
       items: orderForm.items.map(mapCartItemToPixel),


### PR DESCRIPTION
#### What problem is this solving?

The US Regional Product team received a report that the Listrak pixel app was sending duplicate information to Listrak. Specifically, each time a product was added to cart, the app received two `cartChanged` pixel events, resulting in the same information being sent to Listrak twice. 

After [investigation](https://vtex.slack.com/archives/C01PRGM0WG1/p1653399406988839) we determined that the problem only happened when the minicart was configured to automatically open when the `addToCart` pixel event was fired (i.e. when a user adds a product to the cart). In this scenario, the minicart opens while the orderForm is still in the process of being updated. This caused the `cartChanged` event to be triggered twice -- once for each time the orderForm changed. When a product is added to the cart, first the orderForm will not include the new product's `additionalInfo` (such as brand) or its categories. These properties are populated on the second orderForm update.

To eliminate these duplicate `cartChanged` events, this PR adds a conditional to the `BaseContent` useEffect() method so that the pixel event is not emitted if the newest item in the orderForm has `additionalInfo === undefined`.

#### How to test it?

Linked in this workspace: https://arthur--eriksbikeshop.myvtex.com/specialized-2021-como-3-0-step-thru-electric-bike-pr3e25544/p?skuId=8056534

Add a product to cart, then open the console and type `pixelManagerEvents`. There should be only one `cartChanged` event in the array. To see the prior behavior, create a different workspace and repeat the test.