### PR TITLE
Fixed quantity not updating properly in addToCart and removeFromCart …

### DIFF
--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -37,7 +37,7 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
       if (quantityIncreased) {
         const adjustedItem = {
           ...mapCartItemToPixel(item),
-          quantity: quantity - item.quantity,
+          quantity,
         }
 
         push({
@@ -47,7 +47,7 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
       } else {
         const adjustedItem = {
           ...mapCartItemToPixel(item),
-          quantity: item.quantity - quantity,
+          quantity,
         }
 
         push({
@@ -63,7 +63,7 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
 
   const handleRemove = useCallback(
     (uniqueId: string, item: OrderFormItem) => {
-      const adjustedItem = mapCartItemToPixel(item)
+      const adjustedItem = { ...mapCartItemToPixel(item), quantity: 0 }
       push({
         event: 'removeFromCart',
         items: [adjustedItem],


### PR DESCRIPTION
#### What problem is this solving?

The quantity is not updated properly when increasing/decreasing the quantity in the cart causing the datalayer events like addToCart / removeFromCart to have the quantity 1 all the time.  Mainly because it's subtracts the value from the input with the previous value from the item => always will be one.   It needs to always be the quantity from the input in these events.

#### How to test it?

1. Link the app on a workspace where you have minicart.v2 added
2. Decrease / increase quantity on cart + remove item and check dataLayer in console
