### PR TITLE
feat(accessibility): aria properties added to resolve accessibility a…

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -19,5 +19,6 @@
   "store/minicart.checkout-failure": "Message showed when there is a problem to a request to the server.",
   "store/minicart.go-to-checkout": "Go to checkout",
   "store/minicart.empty-state": "store/cart.empty-state",
-  "store/minicart.title": "store/cart.empty-state"
+  "store/minicart.title": "store/cart.empty-state",
+  "store/minicart.icon-button": "minicart.icon-button"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,5 +19,6 @@
   "store/minicart.checkout-failure": "Something went wrong. Please, try again.",
   "store/minicart.go-to-checkout": "Go to checkout",
   "store/minicart.empty-state": "Your cart is empty.",
-  "store/minicart.title": "Cart"
+  "store/minicart.title": "Cart",
+  "store/minicart.icon-button": "Cart icon"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -19,5 +19,6 @@
   "store/minicart.checkout-failure": "Se produjo un error. Por favor, vuelve a intentarlo.",
   "store/minicart.go-to-checkout": "Ir al checkout",
   "store/minicart.empty-state": "Tu carrito está vacío.",
-  "store/minicart.title": "Carrito"
+  "store/minicart.title": "Carrito",
+  "store/minicart.icon-button": "Icono de carrito"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,5 +19,6 @@
   "store/minicart.checkout-failure": "Algo deu errado. Por favor, tente novamente.",
   "store/minicart.go-to-checkout": "Ir para o checkout",
   "store/minicart.empty-state": "Seu carrinho está vazio.",
-  "store/minicart.title": "Carrinho"
+  "store/minicart.title": "Carrinho",
+  "store/minicart.icon-button": "Ícone do carrinho"
 }

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -113,7 +113,6 @@ export const Minicart: FC<MinicartProps> = ({
         >
           {variation === 'drawer' ? (
             <DrawerMode
-              aria-label="Minicart"
               Icon={MinicartIcon}
               backdropMode={backdropMode}
               itemCountMode={itemCountMode}

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -113,6 +113,7 @@ export const Minicart: FC<MinicartProps> = ({
         >
           {variation === 'drawer' ? (
             <DrawerMode
+              aria-label="Minicart"
               Icon={MinicartIcon}
               backdropMode={backdropMode}
               itemCountMode={itemCountMode}

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -98,6 +98,8 @@ const MinicartIconButton: React.FC<Props> = props => {
 
   return (
     <ButtonWithIcon
+      id="miniCartButton"
+      ariaLabel="Open Minicart"
       icon={
         <span className={`${handles.minicartIconContainer} gray relative`}>
           <Icon />

--- a/react/components/MinicartIconButton.tsx
+++ b/react/components/MinicartIconButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useIntl } from 'react-intl'
 import { ButtonWithIcon } from 'vtex.styleguide'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
@@ -65,6 +66,7 @@ const MinicartIconButton: React.FC<Props> = props => {
   const itemQuantity = loading ? 0 : quantity
   const { url: checkoutUrl } = useCheckoutURL()
   const goToCheckout = useCheckout()
+  const intl = useIntl()
 
   const handleClick = () => {
     if (openOnHoverProp) {
@@ -98,10 +100,13 @@ const MinicartIconButton: React.FC<Props> = props => {
 
   return (
     <ButtonWithIcon
-      id="miniCartButton"
-      ariaLabel="Open Minicart"
       icon={
-        <span className={`${handles.minicartIconContainer} gray relative`}>
+        <span 
+          aria-label={intl.formatMessage({
+            id: 'store/minicart.icon-button',
+          })}
+          role="img"
+          className={`${handles.minicartIconContainer} gray relative`}>
           <Icon />
           {showQuantityBadge && (
             <span


### PR DESCRIPTION
#### What problem is this solving?

Adicionado propriedades ARIA para resolver ajustes apontados pelo Lighthouse.
ButtonWithIcon atualmente não aceita a propriedade aria-label. Foi feito um ajuste também no app vtex.styleguide para aceitar essa propriedade.
PR Styleguide: https://github.com/vtex/styleguide/pull/1447

#### How to test it?

[Workspace](https://www.samsclub.com.br/?workspace=testeacessibilidade)

Executar o teste no Lighthouse ou Pagespeed.

#### Screenshots or example usage:

Antes da alteração:
![minicart before](https://github.com/vtex-apps/minicart/assets/22462037/5f4f810c-f929-4837-85ad-03edd258d885)

Depois da alteração (o ajuste não foi mais apontado pelo Lighthouse):
![Minicart After](https://github.com/vtex-apps/minicart/assets/22462037/d7dff1ba-ee99-474d-b028-be85cd162c64)