### PR TITLE
fix: products with attachments were being duplicated when increasing quantity in minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `splitItem` of `minicart-product-list`
 
 ## [2.67.1] - 2023-05-05
 ### Fixed

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -9,22 +9,28 @@ import { mapCartItemToPixel } from './modules/pixelHelper'
 
 const CSS_HANDLES = ['minicartProductListContainer'] as const
 
-const options = {
-  allowedOutdatedData: ['paymentData'],
-}
-
 interface Props {
   renderAsChildren: boolean
+  splitItem?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
-const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
+const ProductList: FC<Props> = ({
+  renderAsChildren,
+  splitItem = true,
+  classes,
+}) => {
   const {
     orderForm: { items },
   } = useOrderForm()
   const { updateQuantity, removeItem } = useOrderItems()
   const { push } = usePixel()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
+
+  const options = {
+    allowedOutdatedData: ['paymentData'],
+    splitItem,
+  }
 
   const handleQuantityChange = useCallback(
     (_: string, quantity: number, item: OrderFormItemWithIndex) => {
@@ -58,7 +64,7 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
 
       updateQuantity({ index: item.index, quantity }, options)
     },
-    [push, updateQuantity]
+    [options, push, updateQuantity]
   )
 
   const handleRemove = useCallback(
@@ -70,7 +76,7 @@ const ProductList: FC<Props> = ({ renderAsChildren, classes }) => {
       })
       removeItem({ uniqueId }, options)
     },
-    [push, removeItem]
+    [options, push, removeItem]
   )
 
   return (


### PR DESCRIPTION
#### What problem is this solving?

This PR aims to fix (add a new param) to the KI: #337069

If a store uses the [product-list](https://developers.vtex.com/vtex-developer-docs/docs/vtex-product-list) component of [Store Framework](https://developers.vtex.com/vtex-developer-docs/docs/getting-started-3), used in the [minicart](https://vtex.io/docs/components/all/vtex.minicart@2.61.1/), cart items may be duplicated when increasing the quantity of an item that has an [attachment](https://help.vtex.com/en/tutorial/adding-an-attachment--7zHMUpuoQE4cAskqEUWScU#) (itemAttachment).

This is because the default [noSplitItem behavior of the API request that updates cart items is false](https://github.com/vtex/vcs.checkout/blob/71bb65b67a94de30b74d4f0ea648f0c61ea43438/src/VTEX%20Checkout/Private%20Assemblies/Vtex.Commerce.Checkout.WebApi/Controllers/OrderFormApiController.cs#L330).

-----

With this PR, now, it's possible to add a prop splitItem in minicart-product-list, so, the customer will choose if they want or not to split the products in minicart. 

#### How to test it?

- Add a [product with attachments](https://iespinoza--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/) in cart.
- Open mini cart
- Increase the quantity of the product with attachments

Expected: Just increase the quantity of the product (A.K.A increase the SKU of a single product)
What was happening: Splitting the product into different products with only 1 quantity


#### Screenshots or example usage:

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Before](https://master--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/)

https://github.com/vtex-apps/minicart/assets/13649073/5cbab702-5495-4de6-a626-1bf4ba2f1dec


[After](https://iespinoza--storecomponents.myvtex.com/star-color-top/p?__bindingAddress=storetheme.vtex.com/)

![image](https://github.com/vtex-apps/minicart/assets/13649073/dea6e3ed-e3f5-45c1-b7cd-2fb551deb5c7)


<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

 We keep the same default behavior (split = true), even though several clients were complaining about that. 
The positive side effect is that this is not going to affect any live store
The negative side effect is that the client will have to change their theme in order to fix/change this behavior

#### Related to / Depends on

https://github.com/vtex-apps/checkout-resources/pull/102
https://github.com/vtex-apps/product-list/pull/159
https://github.com/vtex/order-items/pull/38

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

Split king

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXM1OHBnMjRvZGZjc3d6NXh1eGkxOTJ0ZmQ1eW4yYzh1dXo3cmdvayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oEjHQKtDXpeGN9rW0/giphy.gif)
