### PR TITLE
Change logic of the useVIewCartPixel hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Drawer component onVisibilityChanged property to handle open/close state
+
+### Changed
+- Logic of the useViewCartPixel hook
+
 ## [2.67.1] - 2023-05-05
 ### Fixed
 - Fixes of i18n on readme.md accorrding to task LOC-10558.

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -61,8 +61,8 @@ export const Minicart: FC<MinicartProps> = ({
 
   const { orderForm }: OrderFormContext = useOrderForm()
 
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const { variation, open } = useMinicartState()
+  const [isDrawerOpen, setIsDrawerOpen] = useState(open ?? false)
   const { url: checkoutUrl } = useCheckoutURL()
 
   const onDrawerVisibilityChanged = useCallback(

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -65,8 +65,18 @@ export const Minicart: FC<MinicartProps> = ({
   const { variation, open } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
 
+  const onDrawerVisibilityChanged = useCallback(
+    (visible: boolean) => {
+      setIsDrawerOpen(visible)
+    },
+    [setIsDrawerOpen]
+  )
+
   // for Popup it uses "open" and for Drawer it uses "isDrawerOpen" to send view_cart pixel event
-  useViewCartPixel(variation === 'drawer' ? isDrawerOpen : open, orderForm?.items)
+  useViewCartPixel(
+    variation === 'drawer' ? isDrawerOpen : open,
+    orderForm?.items
+  )
 
   if (variation === 'link') {
     return (
@@ -103,10 +113,6 @@ export const Minicart: FC<MinicartProps> = ({
       </aside>
     )
   }
-
-  const onDrawerVisibilityChanged = useCallback((visible: boolean) => {
-    setIsDrawerOpen(visible)
-  }, [setIsDrawerOpen])
 
   return (
     <aside

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useCallback, useState } from 'react'
 import { IconCart } from 'vtex.store-icons'
 import { BackdropMode } from 'vtex.store-drawer'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
@@ -104,9 +104,9 @@ export const Minicart: FC<MinicartProps> = ({
     )
   }
 
-  const onDrawerVisibilityChanged = (visible: boolean) => {
+  const onDrawerVisibilityChanged = useCallback((visible: boolean) => {
     setIsDrawerOpen(visible)
-  }
+  }, [setIsDrawerOpen])
 
   return (
     <aside

--- a/react/Minicart.tsx
+++ b/react/Minicart.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { IconCart } from 'vtex.store-icons'
 import { BackdropMode } from 'vtex.store-drawer'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
@@ -61,10 +61,12 @@ export const Minicart: FC<MinicartProps> = ({
 
   const { orderForm }: OrderFormContext = useOrderForm()
 
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const { variation, open } = useMinicartState()
   const { url: checkoutUrl } = useCheckoutURL()
 
-  useViewCartPixel(open, orderForm?.items)
+  // for Popup it uses "open" and for Drawer it uses "isDrawerOpen" to send view_cart pixel event
+  useViewCartPixel(variation === 'drawer' ? isDrawerOpen : open, orderForm?.items)
 
   if (variation === 'link') {
     return (
@@ -102,6 +104,10 @@ export const Minicart: FC<MinicartProps> = ({
     )
   }
 
+  const onDrawerVisibilityChanged = (visible: boolean) => {
+    setIsDrawerOpen(visible)
+  }
+
   return (
     <aside
       className={`${handles.minicartWrapperContainer} relative fr flex items-center`}
@@ -121,6 +127,7 @@ export const Minicart: FC<MinicartProps> = ({
               drawerSlideDirection={drawerSlideDirection}
               customPixelEventId={customPixelEventId}
               customPixelEventName={customPixelEventName}
+              onVisibilityChanged={onDrawerVisibilityChanged}
             >
               {children}
             </DrawerMode>

--- a/react/components/DrawerMode.tsx
+++ b/react/components/DrawerMode.tsx
@@ -19,6 +19,7 @@ interface Props {
   backdropMode?: ResponsiveValuesTypes.ResponsiveValue<BackdropMode>
   customPixelEventId?: string
   customPixelEventName?: PixelEventTypes.EventName
+  onVisibilityChanged?: (visible: boolean) => void
 }
 
 const DrawerMode: FC<Props> = ({
@@ -31,6 +32,7 @@ const DrawerMode: FC<Props> = ({
   backdropMode = 'visible',
   customPixelEventId,
   customPixelEventName,
+  onVisibilityChanged,
 }) => {
   const { handles } = useMinicartCssHandles()
 
@@ -41,6 +43,7 @@ const DrawerMode: FC<Props> = ({
       slideDirection={drawerSlideDirection}
       customPixelEventId={customPixelEventId}
       customPixelEventName={customPixelEventName}
+      onVisibilityChanged={onVisibilityChanged}
       customIcon={
         <MinicartIconButton
           Icon={Icon}

--- a/react/legacy/__tests__/MiniCartV2.test.jsx
+++ b/react/legacy/__tests__/MiniCartV2.test.jsx
@@ -47,14 +47,9 @@ describe('<MiniCart /> v2', () => {
       </MinicartStateContext.Provider>
     )
 
-    await wait(
-      async () => {
-        jest.runAllTimers()
-      },
-      {
-        timeout: 1200,
-      }
-    )
+    await wait(async () => {
+      jest.runAllTimers()
+    })
 
     const expectedPixelEvent = {
       event: 'viewCart',
@@ -71,14 +66,9 @@ describe('<MiniCart /> v2', () => {
       </MinicartStateContext.Provider>
     )
 
-    await wait(
-      async () => {
-        jest.runAllTimers()
-      },
-      {
-        timeout: 1200,
-      }
-    )
+    await wait(async () => {
+      jest.runAllTimers()
+    })
 
     const expectedPixelEvent = {
       event: 'viewCart',

--- a/react/legacy/__tests__/MiniCartV2.test.jsx
+++ b/react/legacy/__tests__/MiniCartV2.test.jsx
@@ -1,5 +1,7 @@
+/* eslint-disable global-require */
 import React from 'react'
 import { render, wait } from '@vtex/test-tools/react'
+
 import { Minicart } from '../../Minicart'
 import { MinicartStateContext } from '../../MinicartContext'
 import { transformOrderFormItems } from '../../modules/pixelHelper'
@@ -15,11 +17,13 @@ jest.mock('vtex.order-manager/OrderForm', () => {
   const mockData = require('../__fixtures__/orderForm')
 
   return {
-    useOrderForm: jest.fn(() => ({
-      orderForm: mockData.default
-    })).mockImplementationOnce(() => ({
-      orderForm: []
-    }))
+    useOrderForm: jest
+      .fn(() => ({
+        orderForm: mockData.default,
+      }))
+      .mockImplementationOnce(() => ({
+        orderForm: [],
+      })),
   }
 })
 
@@ -43,9 +47,14 @@ describe('<MiniCart /> v2', () => {
       </MinicartStateContext.Provider>
     )
 
-    await wait(async () => {
-      jest.runAllTimers()
-    })
+    await wait(
+      async () => {
+        jest.runAllTimers()
+      },
+      {
+        timeout: 1200,
+      }
+    )
 
     const expectedPixelEvent = {
       event: 'viewCart',
@@ -55,16 +64,21 @@ describe('<MiniCart /> v2', () => {
     expect(mockedUsePixelPush).toHaveBeenCalledWith(expectedPixelEvent)
   })
 
-	it('should trigger vtex:viewCart when cart is opened and match items when cart is with products', async () => {
+  it('should trigger vtex:viewCart when cart is opened and match items when cart is with products', async () => {
     render(
       <MinicartStateContext.Provider value={minicartMockContextValue}>
         <Minicart variation="drawer" />
       </MinicartStateContext.Provider>
     )
 
-    await wait(async () => {
-      jest.runAllTimers()
-    })
+    await wait(
+      async () => {
+        jest.runAllTimers()
+      },
+      {
+        timeout: 1200,
+      }
+    )
 
     const expectedPixelEvent = {
       event: 'viewCart',
@@ -73,5 +87,4 @@ describe('<MiniCart /> v2', () => {
 
     expect(mockedUsePixelPush).toHaveBeenCalledWith(expectedPixelEvent)
   })
-
 })

--- a/react/modules/pixelHelper.ts
+++ b/react/modules/pixelHelper.ts
@@ -87,7 +87,7 @@ export function transformOrderFormItems(orderFormItems: OrderForm['items']) {
   return orderFormItems.map(item => mapCartItemToPixel(item))
 }
 
-interface PixelCartItem {
+export interface PixelCartItem {
   skuId: string
   variant: string
   price: number

--- a/react/modules/useViewCartPixel.tsx
+++ b/react/modules/useViewCartPixel.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect } from 'react'
 import { usePixel } from 'vtex.pixel-manager'
+import { debounce } from 'debounce'
 
 import { PixelCartItem, transformOrderFormItems } from './pixelHelper'
-import { debounce } from 'debounce'
 
 const useViewCartPixel = (
   isOpen: boolean,
@@ -12,23 +12,23 @@ const useViewCartPixel = (
 
   const transformedItems = transformOrderFormItems(orderFormItems)
 
+  const pushViewCart = useCallback(
+    debounce((items: PixelCartItem[]) => {
+      push({
+        event: 'viewCart',
+        items,
+      })
+    }, 1000),
+    [push]
+  )
+
   useEffect(() => {
     if (!isOpen) {
       return
     }
 
     pushViewCart(transformedItems)
-  }, [isOpen, transformedItems])
-
-  const pushViewCart = useCallback(
-    debounce((items: PixelCartItem[]) => {
-      push({
-        event: 'viewCart',
-        items: items,
-      })
-    }, 1000),
-    [push]
-  );
+  }, [pushViewCart, isOpen, transformedItems])
 }
 
 export default useViewCartPixel

--- a/react/modules/useViewCartPixel.tsx
+++ b/react/modules/useViewCartPixel.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { usePixel } from 'vtex.pixel-manager'
 
-import { transformOrderFormItems } from './pixelHelper'
+import { PixelCartItem, transformOrderFormItems } from './pixelHelper'
+import { debounce } from 'debounce'
 
 const useViewCartPixel = (
   isOpen: boolean,
@@ -16,11 +17,18 @@ const useViewCartPixel = (
       return
     }
 
-    push({
-      event: 'viewCart',
-      items: transformedItems,
-    })
-  }, [push, isOpen, transformedItems])
+    pushViewCart(transformedItems)
+  }, [isOpen, transformedItems])
+
+  const pushViewCart = useCallback(
+    debounce((items: PixelCartItem[]) => {
+      push({
+        event: 'viewCart',
+        items: items,
+      })
+    }, 1000),
+    [push]
+  );
 }
 
 export default useViewCartPixel


### PR DESCRIPTION
#### What problem is this solving?

The app has problems with pushing view_cart pixel event when variant="drawer". This problem happens because of the wrong logic of handling open/close state of the Drawer component. It switches isOpen from true to false and back when user presses on the Cart Button in the store front header:
1. User presses on the Cart button --> isOpen changes to true --> view_cart event is pushed;
2. User presses on the close Drawer button --> nothing changed;
3. User presses on the Cart button --> isOpen changed to false --> view_cart event is not pushed because isOpen state == false.

To solve this wrong behavior I added onVisibilityChanged callback function as a property argument to the Drawer component in the drawer app and made these changes in the minicart app to handle open/close events properly.

#### How to test it?

In the browser inspector console tab type dataLayer to see events that have been pushed. It should add view_cart event on every Drawer opening and when user adds a new product to the cart (at the moment when Drawer is opening)

https://devalex--dunnesstorespreprod.myvtex.com/

#### Screenshots or example usage:

https://github.com/user-attachments/assets/aff7f680-d649-452a-8837-30242f287454

https://github.com/user-attachments/assets/adeb1c36-71e8-45ca-8778-e6e9e3a419d6

![Снимок экрана 2024-08-02 в 15 13 17](https://github.com/user-attachments/assets/c702ae07-fa85-41ee-9db5-9be349b9cb26)

#### Related PR

https://github.com/vtex-apps/drawer/pull/75
