### PR TITLE
feat: forward priceToken when syncing new items with the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Forward the search-signed `priceToken` (Pricing Fallback V2) when syncing new items with the server. The v1 minicart picks an explicit set of fields off each local item before calling `addItem`, so the token was dropped on the way out even when `BuyButton` provided it.
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/react/index.jsx
+++ b/react/index.jsx
@@ -289,13 +289,19 @@ const MiniCart = ({
             pick(['id', 'index', 'quantity', 'seller', 'options'])
           )
 
+          // `priceToken` only rides along on add: that is the mutation that
+          // honours it, while `updateItems` reprices a line already in the cart.
+          const pickAddProps = map(
+            pick(['id', 'index', 'quantity', 'seller', 'options', 'priceToken'])
+          )
+
           // server mutation
           const updateItemsResponse = await mutateUpdateItems(
             pickProps(itemsToUpdate)
           )
 
           // server mutation
-          const addItemsResponse = await addItems(pickProps(itemsToAdd))
+          const addItemsResponse = await addItems(pickAddProps(itemsToAdd))
 
           if (itemsToAdd.length > 0) {
             push({


### PR DESCRIPTION
## Summary

The v1 minicart keeps the cart in local state and later syncs it with the server. Before calling `addItem` it `pick`s a fixed set of fields off each local item, which dropped `priceToken` even when `BuyButton` provided it — the same class of bug as the `adjustForItemInput` whitelist in the `@vtex/order-items` package.

The local state itself was never the problem: the `addToCart` resolver spreads the whole item and persists it as a JSON string, so the token survives all the way to the `pick`.

## Why adds get their own pick

`updateItems` keeps the previous field set. `store-graphql`'s `updateItems` was not switched to `PATCH` in `store-graphql#699` — only `addItem` was — so sending the token there would be dead weight implying support we did not build.

## Ordering

Draft on purpose. Can only merge after `store-graphql#699` publishes, otherwise `priceToken` is not on `OrderFormItemInput` and the mutation is rejected during coercion.

Pairs with the `store-components` PR, which is what puts the token on the local item in the first place.

## Related

[STR-1230](https://vtex-dev.atlassian.net/browse/STR-1230), part of [STR-1132](https://vtex-dev.atlassian.net/browse/STR-1132).

## Test plan

- [x] `yarn test` — 21 passing, no regressions
- [ ] v1 chain end to end after `store-graphql#699` is published
- [ ] Quantity update on an existing line: payload unchanged

Made with [Cursor](https://cursor.com)

[STR-1230]: https://vtex-dev.atlassian.net/browse/STR-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ